### PR TITLE
feat: Implement AST node-level restrictions for JavaScript and Python interpreters

### DIFF
--- a/.context/javascript/architecture.md
+++ b/.context/javascript/architecture.md
@@ -106,7 +106,7 @@ Supports configurable AST node-level restrictions via `allowedNodes` in Language
 
 When implementing support for a new AST node type, you MUST:
 
-1. **Update JavaScriptNodeType**: Add the new node type to the `JavaScriptNodeType` union in `src/javascript/interfaces.ts`
+1. **Update NodeType**: Add the new node type to the `NodeType` union in `src/javascript/interfaces.ts`
 2. **Add Error Type**: Add `<NodeName>NotAllowed` to `SyntaxErrorType` in `src/javascript/error.ts`
 3. **Update Parser**: Add `checkNodeAllowed()` call in the relevant parsing method in `src/javascript/parser.ts`
 4. **Add Safety Check**: Executor already has generic checks, but verify it handles the new node

--- a/.context/javascript/architecture.md
+++ b/.context/javascript/architecture.md
@@ -94,6 +94,27 @@ Configurable language features:
 
 Uses unified frame system with JavaScript-specific extensions for educational descriptions.
 
+### 10. AST Node Restrictions System
+
+Supports configurable AST node-level restrictions via `allowedNodes` in LanguageFeatures:
+
+- `allowedNodes: null | undefined` - All nodes allowed (default behavior)
+- `allowedNodes: []` - No nodes allowed (maximum restriction)
+- `allowedNodes: ["NodeType", ...]` - Only specified nodes allowed
+
+**IMPORTANT: When Adding New AST Node Types**
+
+When implementing support for a new AST node type, you MUST:
+
+1. **Update JavaScriptNodeType**: Add the new node type to the `JavaScriptNodeType` union in `src/javascript/interfaces.ts`
+2. **Add Error Type**: Add `<NodeName>NotAllowed` to `SyntaxErrorType` in `src/javascript/error.ts`
+3. **Update Parser**: Add `checkNodeAllowed()` call in the relevant parsing method in `src/javascript/parser.ts`
+4. **Add Safety Check**: Executor already has generic checks, but verify it handles the new node
+5. **Add Tests**: Add test cases for the new node in `tests/javascript/language-features/allowedNodes.test.ts`
+6. **Update PLAN.md**: Add the new node type to the "Supported AST Node Types" section
+
+This ensures the node restriction system remains complete and consistent.
+
 ## Loop Constructs
 
 ### For Loops

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,150 @@
+# JavaScript Interpreter AST Node Restrictions Implementation
+
+## Overview
+
+This document tracks the implementation of AST node-level restrictions for the JavaScript interpreter. This feature allows external systems (like curriculum/learning platforms) to control which JavaScript language features are available by specifying allowed AST node types.
+
+## Design Principles
+
+1. **No curriculum/level concepts in this repo** - This is pure infrastructure
+2. **Type safety** - Exported `JavaScriptNodeType` for strong typing
+3. **Specific errors** - Each node restriction has its own error type
+4. **Backward compatible** - `null`/`undefined` = all nodes allowed (current behavior)
+5. **Explicit restriction** - Empty array `[]` = no nodes allowed
+
+## Implementation Status
+
+### ✅ Phase 1: Planning & Documentation
+
+- [x] Create PLAN.md to track implementation
+
+### 🔄 Phase 2: Type Definitions
+
+- [ ] Create `JavaScriptNodeType` union type with all supported AST nodes
+- [ ] Update `LanguageFeatures` interface with `allowedNodes` field
+
+### 🔄 Phase 3: Error Handling
+
+- [ ] Add specific `SyntaxErrorType` for each restrictable node
+- [ ] Implement error messages for node restrictions
+
+### 🔄 Phase 4: Parser Implementation
+
+- [ ] Add `isNodeAllowed()` helper method
+- [ ] Add `checkNodeAllowed()` for error throwing
+- [ ] Update statement parsing methods:
+  - [ ] `variableDeclaration()` - VariableDeclaration
+  - [ ] `ifStatement()` - IfStatement
+  - [ ] `forStatement()` - ForStatement
+  - [ ] `whileStatement()` - WhileStatement
+  - [ ] `blockStatement()` - BlockStatement
+- [ ] Update expression parsing methods:
+  - [ ] `assignment()` - AssignmentExpression
+  - [ ] `conditional()` - ConditionalExpression
+  - [ ] `logicalOr()`/`logicalAnd()` - LogicalExpression
+  - [ ] `equality()`/`comparison()` - BinaryExpression
+  - [ ] `unary()` - UnaryExpression/UpdateExpression
+  - [ ] `member()` - MemberExpression
+  - [ ] Array literals - ArrayExpression
+  - [ ] Object literals - DictionaryExpression
+  - [ ] Template literals - TemplateLiteralExpression
+
+### 🔄 Phase 5: Executor Safety
+
+- [ ] Add `assertNodeAllowed()` defensive check
+- [ ] Apply checks in execute methods
+
+### 🔄 Phase 6: Testing
+
+- [ ] Create `tests/javascript/language-features/allowedNodes.test.ts`
+- [ ] Test each node type with allowed/restricted scenarios
+- [ ] Test edge cases (empty array, null, undefined)
+- [ ] Test error messages and types
+
+### 🔄 Phase 7: Documentation
+
+- [ ] Update `.context/javascript/architecture.md` with maintenance notes
+- [ ] Document how to add new AST nodes
+
+### 🔄 Phase 8: Validation
+
+- [ ] Run all existing tests - ensure no regressions
+- [ ] Verify type exports work correctly
+- [ ] Test with example restrictions
+
+## Supported AST Node Types
+
+### Expressions
+
+- `LiteralExpression` - Numbers, strings, booleans, null, undefined
+- `IdentifierExpression` - Variable references
+- `BinaryExpression` - Arithmetic, comparison operators
+- `UnaryExpression` - Negation, NOT, unary +/-
+- `LogicalExpression` - &&, || operators
+- `AssignmentExpression` - Variable assignment
+- `UpdateExpression` - ++, -- operators
+- `GroupingExpression` - Parentheses
+- `ConditionalExpression` - Ternary operator
+- `ArrayExpression` - Array literals
+- `DictionaryExpression` - Object literals
+- `MemberExpression` - Property/element access
+- `TemplateLiteralExpression` - Template strings
+
+### Statements
+
+- `ExpressionStatement` - Expression as statement
+- `VariableDeclaration` - let declarations
+- `BlockStatement` - { } blocks
+- `IfStatement` - if/else statements
+- `ForStatement` - for loops
+- `WhileStatement` - while loops
+
+## Maintenance Notes
+
+### Adding New AST Node Support
+
+When implementing support for a new AST node type:
+
+1. **Update type definition**: Add to `JavaScriptNodeType` in `src/javascript/interfaces.ts`
+2. **Add error type**: Add `<NodeName>NotAllowed` to `SyntaxErrorType` in `src/javascript/error.ts`
+3. **Update parser**: Add restriction check in the relevant parsing method
+4. **Add safety check**: Update executor if needed
+5. **Add tests**: Cover the new node in `allowedNodes.test.ts`
+6. **Update this file**: Add to the "Supported AST Node Types" section
+
+### Example Usage
+
+```typescript
+// Allow only basic expressions and function calls
+const result = interpret(code, {
+  allowedNodes: ["LiteralExpression", "IdentifierExpression", "CallExpression", "ExpressionStatement"],
+});
+
+// Allow everything (default behavior)
+const result = interpret(code, {
+  allowedNodes: null,
+});
+
+// Allow nothing (maximum restriction)
+const result = interpret(code, {
+  allowedNodes: [],
+});
+```
+
+## Testing Strategy
+
+Each node type should have tests covering:
+
+1. **Allowed**: Node in allowedNodes array → code executes
+2. **Restricted**: Node not in allowedNodes → specific error thrown
+3. **Null/undefined**: No restriction → code executes
+4. **Empty array**: Maximum restriction → error thrown
+
+## Related Files
+
+- `src/javascript/interfaces.ts` - Type definitions
+- `src/javascript/error.ts` - Error types
+- `src/javascript/parser.ts` - Parsing logic with restrictions
+- `src/javascript/executor.ts` - Safety checks
+- `tests/javascript/language-features/allowedNodes.test.ts` - Tests
+- `.context/javascript/architecture.md` - Architecture docs

--- a/src/javascript/error.ts
+++ b/src/javascript/error.ts
@@ -28,7 +28,25 @@ export type SyntaxErrorType =
   | "UnimplementedToken"
   | "UnknownCharacter"
   | "UnterminatedComment"
-  | "UnterminatedString";
+  | "UnterminatedString"
+  // Node restriction errors
+  | "LiteralExpressionNotAllowed"
+  | "BinaryExpressionNotAllowed"
+  | "UnaryExpressionNotAllowed"
+  | "GroupingExpressionNotAllowed"
+  | "IdentifierExpressionNotAllowed"
+  | "AssignmentExpressionNotAllowed"
+  | "UpdateExpressionNotAllowed"
+  | "TemplateLiteralExpressionNotAllowed"
+  | "ArrayExpressionNotAllowed"
+  | "MemberExpressionNotAllowed"
+  | "DictionaryExpressionNotAllowed"
+  | "ExpressionStatementNotAllowed"
+  | "VariableDeclarationNotAllowed"
+  | "BlockStatementNotAllowed"
+  | "IfStatementNotAllowed"
+  | "ForStatementNotAllowed"
+  | "WhileStatementNotAllowed";
 
 export class SyntaxError extends Error {
   constructor(

--- a/src/javascript/executor.ts
+++ b/src/javascript/executor.ts
@@ -1,6 +1,6 @@
 import { Environment } from "./environment";
 import type { Expression } from "./expression";
-import type { LanguageFeatures, JavaScriptNodeType } from "./interfaces";
+import type { LanguageFeatures, NodeType } from "./interfaces";
 import {
   LiteralExpression,
   BinaryExpression,
@@ -117,7 +117,7 @@ export class Executor {
 
   private assertNodeAllowed(node: Statement | Expression): void {
     // Get the node type name from the constructor
-    const nodeType = node.constructor.name as JavaScriptNodeType;
+    const nodeType = node.constructor.name as NodeType;
 
     // If allowedNodes is null or undefined, all nodes are allowed
     if (this.languageFeatures.allowedNodes === null || this.languageFeatures.allowedNodes === undefined) {

--- a/src/javascript/index.ts
+++ b/src/javascript/index.ts
@@ -1,3 +1,4 @@
 export * from "./scanner";
 export * from "./token";
 export * from "./interpreter";
+export type { NodeType, LanguageFeatures } from "./interfaces";

--- a/src/javascript/index.ts
+++ b/src/javascript/index.ts
@@ -1,4 +1,3 @@
-export * from "./scanner";
-export * from "./token";
-export * from "./interpreter";
+export { interpret } from "./interpreter";
+export type { InterpretResult } from "./interpreter";
 export type { NodeType, LanguageFeatures } from "./interfaces";

--- a/src/javascript/interfaces.ts
+++ b/src/javascript/interfaces.ts
@@ -1,3 +1,25 @@
+// All supported AST node types in the JavaScript interpreter
+export type JavaScriptNodeType =
+  // Expressions
+  | "LiteralExpression"
+  | "BinaryExpression"
+  | "UnaryExpression"
+  | "GroupingExpression"
+  | "IdentifierExpression"
+  | "AssignmentExpression"
+  | "UpdateExpression"
+  | "TemplateLiteralExpression"
+  | "ArrayExpression"
+  | "MemberExpression"
+  | "DictionaryExpression"
+  // Statements
+  | "ExpressionStatement"
+  | "VariableDeclaration"
+  | "BlockStatement"
+  | "IfStatement"
+  | "ForStatement"
+  | "WhileStatement";
+
 export interface LanguageFeatures {
   excludeList?: string[];
   includeList?: string[];
@@ -7,4 +29,9 @@ export interface LanguageFeatures {
   allowTypeCoercion?: boolean;
   oneStatementPerLine?: boolean;
   enforceStrictEquality?: boolean;
+  // AST node-level restrictions
+  // null/undefined = all nodes allowed (default behavior)
+  // [] = no nodes allowed
+  // ["NodeType", ...] = only specified nodes allowed
+  allowedNodes?: JavaScriptNodeType[] | null;
 }

--- a/src/javascript/interfaces.ts
+++ b/src/javascript/interfaces.ts
@@ -1,5 +1,5 @@
 // All supported AST node types in the JavaScript interpreter
-export type JavaScriptNodeType =
+export type NodeType =
   // Expressions
   | "LiteralExpression"
   | "BinaryExpression"
@@ -33,5 +33,5 @@ export interface LanguageFeatures {
   // null/undefined = all nodes allowed (default behavior)
   // [] = no nodes allowed
   // ["NodeType", ...] = only specified nodes allowed
-  allowedNodes?: JavaScriptNodeType[] | null;
+  allowedNodes?: NodeType[] | null;
 }

--- a/src/javascript/parser.ts
+++ b/src/javascript/parser.ts
@@ -26,7 +26,7 @@ import {
 } from "./statement";
 import { type Token, type TokenType } from "./token";
 import { translate } from "./translator";
-import type { LanguageFeatures, JavaScriptNodeType } from "./interfaces";
+import type { LanguageFeatures, NodeType } from "./interfaces";
 
 export class Parser {
   private readonly scanner: Scanner;
@@ -39,7 +39,7 @@ export class Parser {
     this.languageFeatures = languageFeatures || {};
   }
 
-  private isNodeAllowed(nodeType: JavaScriptNodeType): boolean {
+  private isNodeAllowed(nodeType: NodeType): boolean {
     // null or undefined = all nodes allowed (default behavior)
     if (this.languageFeatures.allowedNodes === null || this.languageFeatures.allowedNodes === undefined) {
       return true;
@@ -48,15 +48,15 @@ export class Parser {
     return this.languageFeatures.allowedNodes.includes(nodeType);
   }
 
-  private checkNodeAllowed(nodeType: JavaScriptNodeType, errorType: SyntaxErrorType, location: Location): void {
+  private checkNodeAllowed(nodeType: NodeType, errorType: SyntaxErrorType, location: Location): void {
     if (!this.isNodeAllowed(nodeType)) {
       const friendlyName = this.getNodeFriendlyName(nodeType);
       this.error(errorType, location, { nodeType, friendlyName });
     }
   }
 
-  private getNodeFriendlyName(nodeType: JavaScriptNodeType): string {
-    const friendlyNames: Record<JavaScriptNodeType, string> = {
+  private getNodeFriendlyName(nodeType: NodeType): string {
+    const friendlyNames: Record<NodeType, string> = {
       LiteralExpression: "Literals",
       BinaryExpression: "Binary expressions",
       UnaryExpression: "Unary expressions",

--- a/src/python/error.ts
+++ b/src/python/error.ts
@@ -32,7 +32,23 @@ export type SyntaxErrorType =
   | "UnimplementedToken"
   | "UnknownCharacter"
   | "UnterminatedComment"
-  | "UnterminatedString";
+  | "UnterminatedString"
+  // Node restriction errors
+  | "LiteralExpressionNotAllowed"
+  | "BinaryExpressionNotAllowed"
+  | "UnaryExpressionNotAllowed"
+  | "GroupingExpressionNotAllowed"
+  | "IdentifierExpressionNotAllowed"
+  | "ListExpressionNotAllowed"
+  | "SubscriptExpressionNotAllowed"
+  | "ExpressionStatementNotAllowed"
+  | "PrintStatementNotAllowed"
+  | "AssignmentStatementNotAllowed"
+  | "BlockStatementNotAllowed"
+  | "IfStatementNotAllowed"
+  | "ForInStatementNotAllowed"
+  | "BreakStatementNotAllowed"
+  | "ContinueStatementNotAllowed";
 
 export class SyntaxError extends Error {
   constructor(

--- a/src/python/index.ts
+++ b/src/python/index.ts
@@ -1,3 +1,4 @@
 export * from "./scanner";
 export * from "./token";
 export * from "./interpreter";
+export type { NodeType, LanguageFeatures } from "./interfaces";

--- a/src/python/index.ts
+++ b/src/python/index.ts
@@ -1,4 +1,3 @@
-export * from "./scanner";
-export * from "./token";
-export * from "./interpreter";
+export { interpret } from "./interpreter";
+export type { InterpretResult } from "./interpreter";
 export type { NodeType, LanguageFeatures } from "./interfaces";

--- a/src/python/interfaces.ts
+++ b/src/python/interfaces.ts
@@ -1,6 +1,14 @@
+// Python AST node types - stub for now, to be filled in later
+export type NodeType = never; // Empty union type for now
+
 export interface LanguageFeatures {
   excludeList?: string[];
   includeList?: string[];
   allowTruthiness?: boolean;
   allowTypeCoercion?: boolean;
+  // AST node-level restrictions
+  // null/undefined = all nodes allowed (default behavior)
+  // [] = no nodes allowed
+  // ["NodeType", ...] = only specified nodes allowed
+  allowedNodes?: NodeType[] | null;
 }

--- a/src/python/interfaces.ts
+++ b/src/python/interfaces.ts
@@ -1,5 +1,22 @@
-// Python AST node types - stub for now, to be filled in later
-export type NodeType = never; // Empty union type for now
+// All supported AST node types in the Python interpreter
+export type NodeType =
+  // Expressions
+  | "LiteralExpression"
+  | "BinaryExpression"
+  | "UnaryExpression"
+  | "GroupingExpression"
+  | "IdentifierExpression"
+  | "ListExpression"
+  | "SubscriptExpression"
+  // Statements
+  | "ExpressionStatement"
+  | "PrintStatement"
+  | "AssignmentStatement"
+  | "BlockStatement"
+  | "IfStatement"
+  | "ForInStatement"
+  | "BreakStatement"
+  | "ContinueStatement";
 
 export interface LanguageFeatures {
   excludeList?: string[];

--- a/src/python/interpreter.ts
+++ b/src/python/interpreter.ts
@@ -18,7 +18,7 @@ export function interpret(
 ): InterpretResult {
   try {
     // Parse the source code (compilation step)
-    const parser = new Parser(fileName);
+    const parser = new Parser(fileName, languageFeatures);
     const statements = parser.parse(sourceCode);
 
     // Execute statements

--- a/tests/javascript/language-features/allowedNodes.test.ts
+++ b/tests/javascript/language-features/allowedNodes.test.ts
@@ -1,0 +1,622 @@
+import { interpret } from "@javascript/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
+import { SyntaxError } from "@javascript/error";
+import type { JavaScriptNodeType } from "@javascript/interfaces";
+
+describe("JavaScript allowedNodes feature", () => {
+  describe("allowedNodes: null (default)", () => {
+    test("allows all node types when allowedNodes is null", () => {
+      const code = `
+        let x = 5;
+        x = x + 1;
+        if (x > 5) {
+          x = 10;
+        }
+        for (let i = 0; i < 3; i = i + 1) {
+          x = x + 1;
+        }
+      `;
+      const { error, frames } = interpret(code, { allowedNodes: null });
+      expect(error).toBeNull();
+      expect(frames.length).toBeGreaterThan(0);
+    });
+
+    test("allows all node types when allowedNodes is undefined", () => {
+      const code = `
+        let x = 5;
+        x = x + 1;
+        if (x > 5) {
+          x = 10;
+        }
+      `;
+      const { error, frames } = interpret(code);
+      expect(error).toBeNull();
+      expect(frames.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("allowedNodes: [] (empty array)", () => {
+    test("prevents all parsing when allowedNodes is empty", () => {
+      const code = `5;`;
+      const { error, frames } = interpret(code, { allowedNodes: [] });
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error?.type).toBe("ExpressionStatementNotAllowed");
+      expect(frames).toHaveLength(0);
+    });
+
+    test("cannot even parse literals with empty allowedNodes", () => {
+      const code = `42`;
+      const { error, frames } = interpret(code, { allowedNodes: [] });
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error?.type).toBe("ExpressionStatementNotAllowed");
+      expect(frames).toHaveLength(0);
+    });
+  });
+
+  describe("Statement restrictions", () => {
+    describe("VariableDeclaration", () => {
+      test("allows variable declarations when included", () => {
+        const code = `let x = 5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents variable declarations when not included", () => {
+        const code = `let x = 5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["LiteralExpression", "ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("VariableDeclarationNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("IfStatement", () => {
+      test("allows if statements when included", () => {
+        const code = `if (true) { 1; }`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "IfStatement",
+          "BlockStatement",
+          "LiteralExpression",
+          "ExpressionStatement",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents if statements when not included", () => {
+        const code = `if (true) { 1; }`;
+        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "LiteralExpression", "ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("IfStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ForStatement", () => {
+      test("allows for loops when included", () => {
+        const code = `for (let i = 0; i < 3; i = i + 1) { }`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "ForStatement",
+          "VariableDeclaration",
+          "BlockStatement",
+          "LiteralExpression",
+          "IdentifierExpression",
+          "BinaryExpression",
+          "AssignmentExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents for loops when not included", () => {
+        const code = `for (let i = 0; i < 3; i = i + 1) { }`;
+        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ForStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("WhileStatement", () => {
+      test("allows while loops when included", () => {
+        const code = `while (false) { }`;
+        const allowedNodes: JavaScriptNodeType[] = ["WhileStatement", "BlockStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents while loops when not included", () => {
+        const code = `while (false) { }`;
+        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("WhileStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("BlockStatement", () => {
+      test("allows blocks when included", () => {
+        const code = `{ 1; }`;
+        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents blocks when not included", () => {
+        const code = `{ 1; }`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("BlockStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ExpressionStatement", () => {
+      test("allows expression statements when included", () => {
+        const code = `5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents expression statements when not included", () => {
+        const code = `5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ExpressionStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("Expression restrictions", () => {
+    describe("LiteralExpression", () => {
+      test("allows literals when included", () => {
+        const code = `42;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents literals when not included", () => {
+        const code = `42;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("LiteralExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+
+      test("prevents all literal types", () => {
+        const testCases = [
+          { code: `true;`, desc: "boolean true" },
+          { code: `false;`, desc: "boolean false" },
+          { code: `null;`, desc: "null" },
+          { code: `undefined;`, desc: "undefined" },
+          { code: `42;`, desc: "number" },
+          { code: `"hello";`, desc: "string" },
+        ];
+
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement"];
+
+        for (const { code, desc } of testCases) {
+          const { error } = interpret(code, { allowedNodes });
+          expect(error).toBeInstanceOf(SyntaxError);
+          expect(error?.type).toBe("LiteralExpressionNotAllowed");
+        }
+      });
+    });
+
+    describe("BinaryExpression", () => {
+      test("allows binary expressions when included", () => {
+        const code = `1 + 2;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "BinaryExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents binary expressions when not included", () => {
+        const code = `1 + 2;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("BinaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+
+      test("prevents all binary operators", () => {
+        const testCases = [
+          { code: `1 + 2;`, op: "addition" },
+          { code: `1 - 2;`, op: "subtraction" },
+          { code: `1 * 2;`, op: "multiplication" },
+          { code: `1 / 2;`, op: "division" },
+          { code: `1 < 2;`, op: "less than" },
+          { code: `1 > 2;`, op: "greater than" },
+          { code: `1 <= 2;`, op: "less than or equal" },
+          { code: `1 >= 2;`, op: "greater than or equal" },
+          { code: `1 == 2;`, op: "equality" },
+          { code: `1 != 2;`, op: "inequality" },
+          { code: `true && false;`, op: "logical AND" },
+          { code: `true || false;`, op: "logical OR" },
+        ];
+
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+
+        for (const { code, op } of testCases) {
+          const { error } = interpret(code, { allowedNodes });
+          expect(error).toBeInstanceOf(SyntaxError);
+          expect(error?.type).toBe("BinaryExpressionNotAllowed");
+        }
+      });
+    });
+
+    describe("UnaryExpression", () => {
+      test("allows unary expressions when included", () => {
+        const code = `-5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "UnaryExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents unary expressions when not included", () => {
+        const code = `-5;`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("UnaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("AssignmentExpression", () => {
+      test("allows assignments when included", () => {
+        const code = `let x = 5; x = 10;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "AssignmentExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+        expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(10);
+      });
+
+      test("prevents assignments when not included", () => {
+        const code = `let x = 5; x = 10;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("AssignmentExpressionNotAllowed");
+      });
+    });
+
+    describe("UpdateExpression", () => {
+      test("allows update expressions when included", () => {
+        const code = `let x = 5; x++;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "UpdateExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+        expect((frames[frames.length - 1] as TestAugmentedFrame).variables.x.value).toBe(6);
+      });
+
+      test("prevents prefix increment when not included", () => {
+        const code = `let x = 5; ++x;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("UpdateExpressionNotAllowed");
+      });
+
+      test("prevents postfix decrement when not included", () => {
+        const code = `let x = 5; x--;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("UpdateExpressionNotAllowed");
+      });
+    });
+
+    describe("IdentifierExpression", () => {
+      test("allows identifiers when included", () => {
+        const code = `let x = 5; x;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents identifiers when not included", () => {
+        const code = `let x = 5; x;`;
+        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("IdentifierExpressionNotAllowed");
+      });
+    });
+
+    describe("GroupingExpression", () => {
+      test("allows grouping when included", () => {
+        const code = `(5);`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "GroupingExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents grouping when not included", () => {
+        const code = `(5);`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("GroupingExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ArrayExpression", () => {
+      test("allows arrays when included", () => {
+        const code = `[1, 2, 3];`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "ArrayExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents arrays when not included", () => {
+        const code = `[1, 2, 3];`;
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ArrayExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("DictionaryExpression", () => {
+      test("allows objects when included", () => {
+        const code = `({ x: 5, y: 10 });`; // Object literal needs parentheses at statement level
+        const allowedNodes: JavaScriptNodeType[] = [
+          "ExpressionStatement",
+          "GroupingExpression",
+          "DictionaryExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents objects when not included", () => {
+        const code = `let obj = { x: 5 };`; // Use in variable declaration to avoid ambiguity
+        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("DictionaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("MemberExpression", () => {
+      test("allows member access when included", () => {
+        const code = `let arr = [1, 2]; arr[0];`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "ArrayExpression",
+          "MemberExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents bracket notation when not included", () => {
+        const code = `let arr = [1, 2]; arr[0];`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "ArrayExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("MemberExpressionNotAllowed");
+      });
+
+      test("prevents dot notation when not included", () => {
+        const code = `let obj = { x: 5 }; obj.x;`;
+        const allowedNodes: JavaScriptNodeType[] = [
+          "VariableDeclaration",
+          "ExpressionStatement",
+          "DictionaryExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("MemberExpressionNotAllowed");
+      });
+    });
+
+    describe("TemplateLiteralExpression", () => {
+      test("allows template literals when included", () => {
+        const code = "`hello world`;";
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "TemplateLiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents template literals when not included", () => {
+        const code = "`hello`;";
+        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("TemplateLiteralExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("Complex scenarios", () => {
+    test("allows only literals and expression statements", () => {
+      const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+
+      // Should work
+      const { error: error1 } = interpret(`5;`, { allowedNodes });
+      expect(error1).toBeNull();
+
+      // Should fail - needs identifier
+      const { error: error2 } = interpret(`let x = 5;`, { allowedNodes });
+      expect(error2?.type).toBe("VariableDeclarationNotAllowed");
+
+      // Should fail - needs binary expression
+      const { error: error3 } = interpret(`1 + 2;`, { allowedNodes });
+      expect(error3?.type).toBe("BinaryExpressionNotAllowed");
+    });
+
+    test("allows basic arithmetic only", () => {
+      const allowedNodes: JavaScriptNodeType[] = [
+        "ExpressionStatement",
+        "LiteralExpression",
+        "BinaryExpression",
+        "GroupingExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(`(1 + 2) * 3;`, { allowedNodes });
+      expect(error1).toBeNull();
+      expect(frames1.length).toBeGreaterThan(0);
+
+      // Should fail - needs variable declaration
+      const { error: error2 } = interpret(`let x = 1 + 2;`, { allowedNodes });
+      expect(error2?.type).toBe("VariableDeclarationNotAllowed");
+    });
+
+    test("allows variables but no control flow", () => {
+      const allowedNodes: JavaScriptNodeType[] = [
+        "VariableDeclaration",
+        "ExpressionStatement",
+        "AssignmentExpression",
+        "IdentifierExpression",
+        "LiteralExpression",
+        "BinaryExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(
+        `
+        let x = 5;
+        x = x + 1;
+        x;
+      `,
+        { allowedNodes }
+      );
+      expect(error1).toBeNull();
+      expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(6);
+
+      // Should fail - needs if statement
+      const { error: error2 } = interpret(
+        `
+        let x = 5;
+        if (x > 0) { x = 10; }
+      `,
+        { allowedNodes }
+      );
+      expect(error2?.type).toBe("IfStatementNotAllowed");
+    });
+
+    test("allows control flow but no loops", () => {
+      const allowedNodes: JavaScriptNodeType[] = [
+        "VariableDeclaration",
+        "IfStatement",
+        "BlockStatement",
+        "ExpressionStatement",
+        "AssignmentExpression",
+        "BinaryExpression",
+        "IdentifierExpression",
+        "LiteralExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(
+        `
+        let x = 5;
+        if (x > 0) {
+          x = 10;
+        }
+      `,
+        { allowedNodes }
+      );
+      expect(error1).toBeNull();
+      expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(10);
+
+      // Should fail - needs for statement
+      const { error: error2 } = interpret(
+        `
+        for (let i = 0; i < 3; i = i + 1) { }
+      `,
+        { allowedNodes }
+      );
+      expect(error2?.type).toBe("ForStatementNotAllowed");
+
+      // Should fail - needs while statement
+      const { error: error3 } = interpret(
+        `
+        while (false) { }
+      `,
+        { allowedNodes }
+      );
+      expect(error3?.type).toBe("WhileStatementNotAllowed");
+    });
+  });
+});

--- a/tests/javascript/language-features/allowedNodes.test.ts
+++ b/tests/javascript/language-features/allowedNodes.test.ts
@@ -1,7 +1,7 @@
 import { interpret } from "@javascript/interpreter";
 import type { TestAugmentedFrame } from "@shared/frames";
 import { SyntaxError } from "@javascript/error";
-import type { JavaScriptNodeType } from "@javascript/interfaces";
+import type { NodeType } from "@javascript/interfaces";
 
 describe("JavaScript allowedNodes feature", () => {
   describe("allowedNodes: null (default)", () => {
@@ -57,7 +57,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("VariableDeclaration", () => {
       test("allows variable declarations when included", () => {
         const code = `let x = 5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["VariableDeclaration", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -65,7 +65,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents variable declarations when not included", () => {
         const code = `let x = 5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["LiteralExpression", "ExpressionStatement"];
+        const allowedNodes: NodeType[] = ["LiteralExpression", "ExpressionStatement"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("VariableDeclarationNotAllowed");
@@ -76,12 +76,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("IfStatement", () => {
       test("allows if statements when included", () => {
         const code = `if (true) { 1; }`;
-        const allowedNodes: JavaScriptNodeType[] = [
-          "IfStatement",
-          "BlockStatement",
-          "LiteralExpression",
-          "ExpressionStatement",
-        ];
+        const allowedNodes: NodeType[] = ["IfStatement", "BlockStatement", "LiteralExpression", "ExpressionStatement"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -89,7 +84,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents if statements when not included", () => {
         const code = `if (true) { 1; }`;
-        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "LiteralExpression", "ExpressionStatement"];
+        const allowedNodes: NodeType[] = ["BlockStatement", "LiteralExpression", "ExpressionStatement"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("IfStatementNotAllowed");
@@ -100,7 +95,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("ForStatement", () => {
       test("allows for loops when included", () => {
         const code = `for (let i = 0; i < 3; i = i + 1) { }`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "ForStatement",
           "VariableDeclaration",
           "BlockStatement",
@@ -116,7 +111,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents for loops when not included", () => {
         const code = `for (let i = 0; i < 3; i = i + 1) { }`;
-        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["VariableDeclaration", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ForStatementNotAllowed");
@@ -127,7 +122,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("WhileStatement", () => {
       test("allows while loops when included", () => {
         const code = `while (false) { }`;
-        const allowedNodes: JavaScriptNodeType[] = ["WhileStatement", "BlockStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["WhileStatement", "BlockStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -135,7 +130,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents while loops when not included", () => {
         const code = `while (false) { }`;
-        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["BlockStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("WhileStatementNotAllowed");
@@ -146,7 +141,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("BlockStatement", () => {
       test("allows blocks when included", () => {
         const code = `{ 1; }`;
-        const allowedNodes: JavaScriptNodeType[] = ["BlockStatement", "ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["BlockStatement", "ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -154,7 +149,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents blocks when not included", () => {
         const code = `{ 1; }`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("BlockStatementNotAllowed");
@@ -165,7 +160,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("ExpressionStatement", () => {
       test("allows expression statements when included", () => {
         const code = `5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -173,7 +168,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents expression statements when not included", () => {
         const code = `5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["LiteralExpression"];
+        const allowedNodes: NodeType[] = ["LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ExpressionStatementNotAllowed");
@@ -186,7 +181,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("LiteralExpression", () => {
       test("allows literals when included", () => {
         const code = `42;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -194,7 +189,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents literals when not included", () => {
         const code = `42;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("LiteralExpressionNotAllowed");
@@ -211,7 +206,7 @@ describe("JavaScript allowedNodes feature", () => {
           { code: `"hello";`, desc: "string" },
         ];
 
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement"];
 
         for (const { code, desc } of testCases) {
           const { error } = interpret(code, { allowedNodes });
@@ -224,7 +219,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("BinaryExpression", () => {
       test("allows binary expressions when included", () => {
         const code = `1 + 2;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "BinaryExpression", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "BinaryExpression", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -232,7 +227,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents binary expressions when not included", () => {
         const code = `1 + 2;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("BinaryExpressionNotAllowed");
@@ -255,7 +250,7 @@ describe("JavaScript allowedNodes feature", () => {
           { code: `true || false;`, op: "logical OR" },
         ];
 
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
 
         for (const { code, op } of testCases) {
           const { error } = interpret(code, { allowedNodes });
@@ -268,7 +263,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("UnaryExpression", () => {
       test("allows unary expressions when included", () => {
         const code = `-5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "UnaryExpression", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "UnaryExpression", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -276,7 +271,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents unary expressions when not included", () => {
         const code = `-5;`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("UnaryExpressionNotAllowed");
@@ -287,7 +282,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("AssignmentExpression", () => {
       test("allows assignments when included", () => {
         const code = `let x = 5; x = 10;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "AssignmentExpression",
@@ -302,7 +297,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents assignments when not included", () => {
         const code = `let x = 5; x = 10;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "IdentifierExpression",
@@ -317,7 +312,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("UpdateExpression", () => {
       test("allows update expressions when included", () => {
         const code = `let x = 5; x++;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "UpdateExpression",
@@ -332,7 +327,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents prefix increment when not included", () => {
         const code = `let x = 5; ++x;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "IdentifierExpression",
@@ -345,7 +340,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents postfix decrement when not included", () => {
         const code = `let x = 5; x--;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "IdentifierExpression",
@@ -360,7 +355,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("IdentifierExpression", () => {
       test("allows identifiers when included", () => {
         const code = `let x = 5; x;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "IdentifierExpression",
@@ -373,7 +368,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents identifiers when not included", () => {
         const code = `let x = 5; x;`;
-        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["VariableDeclaration", "ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("IdentifierExpressionNotAllowed");
@@ -383,7 +378,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("GroupingExpression", () => {
       test("allows grouping when included", () => {
         const code = `(5);`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "GroupingExpression", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "GroupingExpression", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -391,7 +386,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents grouping when not included", () => {
         const code = `(5);`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("GroupingExpressionNotAllowed");
@@ -402,7 +397,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("ArrayExpression", () => {
       test("allows arrays when included", () => {
         const code = `[1, 2, 3];`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "ArrayExpression", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "ArrayExpression", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -410,7 +405,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents arrays when not included", () => {
         const code = `[1, 2, 3];`;
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ArrayExpressionNotAllowed");
@@ -421,7 +416,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("DictionaryExpression", () => {
       test("allows objects when included", () => {
         const code = `({ x: 5, y: 10 });`; // Object literal needs parentheses at statement level
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "ExpressionStatement",
           "GroupingExpression",
           "DictionaryExpression",
@@ -434,7 +429,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents objects when not included", () => {
         const code = `let obj = { x: 5 };`; // Use in variable declaration to avoid ambiguity
-        const allowedNodes: JavaScriptNodeType[] = ["VariableDeclaration", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["VariableDeclaration", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("DictionaryExpressionNotAllowed");
@@ -445,7 +440,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("MemberExpression", () => {
       test("allows member access when included", () => {
         const code = `let arr = [1, 2]; arr[0];`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "ArrayExpression",
@@ -460,7 +455,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents bracket notation when not included", () => {
         const code = `let arr = [1, 2]; arr[0];`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "ArrayExpression",
@@ -474,7 +469,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents dot notation when not included", () => {
         const code = `let obj = { x: 5 }; obj.x;`;
-        const allowedNodes: JavaScriptNodeType[] = [
+        const allowedNodes: NodeType[] = [
           "VariableDeclaration",
           "ExpressionStatement",
           "DictionaryExpression",
@@ -490,7 +485,7 @@ describe("JavaScript allowedNodes feature", () => {
     describe("TemplateLiteralExpression", () => {
       test("allows template literals when included", () => {
         const code = "`hello world`;";
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "TemplateLiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "TemplateLiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
@@ -498,7 +493,7 @@ describe("JavaScript allowedNodes feature", () => {
 
       test("prevents template literals when not included", () => {
         const code = "`hello`;";
-        const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
         const { error, frames } = interpret(code, { allowedNodes });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("TemplateLiteralExpressionNotAllowed");
@@ -509,7 +504,7 @@ describe("JavaScript allowedNodes feature", () => {
 
   describe("Complex scenarios", () => {
     test("allows only literals and expression statements", () => {
-      const allowedNodes: JavaScriptNodeType[] = ["ExpressionStatement", "LiteralExpression"];
+      const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
 
       // Should work
       const { error: error1 } = interpret(`5;`, { allowedNodes });
@@ -525,7 +520,7 @@ describe("JavaScript allowedNodes feature", () => {
     });
 
     test("allows basic arithmetic only", () => {
-      const allowedNodes: JavaScriptNodeType[] = [
+      const allowedNodes: NodeType[] = [
         "ExpressionStatement",
         "LiteralExpression",
         "BinaryExpression",
@@ -543,7 +538,7 @@ describe("JavaScript allowedNodes feature", () => {
     });
 
     test("allows variables but no control flow", () => {
-      const allowedNodes: JavaScriptNodeType[] = [
+      const allowedNodes: NodeType[] = [
         "VariableDeclaration",
         "ExpressionStatement",
         "AssignmentExpression",
@@ -576,7 +571,7 @@ describe("JavaScript allowedNodes feature", () => {
     });
 
     test("allows control flow but no loops", () => {
-      const allowedNodes: JavaScriptNodeType[] = [
+      const allowedNodes: NodeType[] = [
         "VariableDeclaration",
         "IfStatement",
         "BlockStatement",

--- a/tests/python/language-features/allowedNodes.test.ts
+++ b/tests/python/language-features/allowedNodes.test.ts
@@ -1,0 +1,563 @@
+import { interpret } from "@python/interpreter";
+import type { TestAugmentedFrame } from "@shared/frames";
+import { SyntaxError } from "@python/error";
+import type { NodeType } from "@python/interfaces";
+import { changeLanguage } from "@python/translator";
+
+describe("Python allowedNodes feature", () => {
+  beforeEach(() => {
+    changeLanguage("en");
+  });
+
+  describe("allowedNodes: null (default)", () => {
+    test("allows all node types when allowedNodes is null", () => {
+      const code = `
+x = 5
+x = x + 1
+if x > 5:
+    x = 10
+for i in [1, 2, 3]:
+    x = x + 1
+      `.trim();
+      const { error, frames } = interpret(code, { allowedNodes: null });
+      expect(error).toBeNull();
+      expect(frames.length).toBeGreaterThan(0);
+    });
+
+    test("allows all node types when allowedNodes is undefined", () => {
+      const code = `
+x = 5
+x = x + 1
+if x > 5:
+    x = 10
+      `.trim();
+      const { error, frames } = interpret(code);
+      expect(error).toBeNull();
+      expect(frames.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("allowedNodes: [] (empty array)", () => {
+    test("prevents all parsing when allowedNodes is empty", () => {
+      const code = `5`;
+      const { error, frames } = interpret(code, { allowedNodes: [] });
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error?.type).toBe("ExpressionStatementNotAllowed");
+      expect(frames).toHaveLength(0);
+    });
+
+    test("cannot even parse literals with empty allowedNodes", () => {
+      const code = `42`;
+      const { error, frames } = interpret(code, { allowedNodes: [] });
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect(error?.type).toBe("ExpressionStatementNotAllowed");
+      expect(frames).toHaveLength(0);
+    });
+  });
+
+  describe("Statement restrictions", () => {
+    describe("AssignmentStatement", () => {
+      test("allows assignments when included", () => {
+        const code = `x = 5`;
+        const allowedNodes: NodeType[] = ["AssignmentStatement", "LiteralExpression", "IdentifierExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents assignments when not included", () => {
+        const code = `x = 5`;
+        const allowedNodes: NodeType[] = ["LiteralExpression", "ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("AssignmentStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("IfStatement", () => {
+      test("allows if statements when included", () => {
+        const code = `
+if True:
+    1
+        `.trim();
+        const allowedNodes: NodeType[] = ["IfStatement", "BlockStatement", "LiteralExpression", "ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents if statements when not included", () => {
+        const code = `
+if True:
+    1
+        `.trim();
+        const allowedNodes: NodeType[] = ["BlockStatement", "LiteralExpression", "ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("IfStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ForInStatement", () => {
+      test("allows for loops when included", () => {
+        const code = `
+for i in [1, 2, 3]:
+    x = i
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "ForInStatement",
+          "BlockStatement",
+          "ListExpression",
+          "LiteralExpression",
+          "IdentifierExpression",
+          "AssignmentStatement",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents for loops when not included", () => {
+        const code = `
+for i in [1, 2]:
+    x = i
+        `.trim();
+        const allowedNodes: NodeType[] = ["ListExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ForInStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("BreakStatement", () => {
+      test("allows break statements when included", () => {
+        const code = `
+for i in [1]:
+    break
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "ForInStatement",
+          "BreakStatement",
+          "BlockStatement",
+          "ListExpression",
+          "LiteralExpression",
+          "IdentifierExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents break statements when not included", () => {
+        const code = `
+for i in [1]:
+    break
+        `.trim();
+        const allowedNodes: NodeType[] = ["ForInStatement", "BlockStatement", "ListExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("BreakStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ContinueStatement", () => {
+      test("allows continue statements when included", () => {
+        const code = `
+for i in [1]:
+    continue
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "ForInStatement",
+          "ContinueStatement",
+          "BlockStatement",
+          "ListExpression",
+          "LiteralExpression",
+          "IdentifierExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents continue statements when not included", () => {
+        const code = `
+for i in [1]:
+    continue
+        `.trim();
+        const allowedNodes: NodeType[] = ["ForInStatement", "BlockStatement", "ListExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ContinueStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("BlockStatement", () => {
+      test("allows blocks when included", () => {
+        const code = `
+if True:
+    1
+        `.trim();
+        const allowedNodes: NodeType[] = ["IfStatement", "BlockStatement", "ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents blocks when not included", () => {
+        const code = `
+if True:
+    1
+        `.trim();
+        const allowedNodes: NodeType[] = ["IfStatement", "ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("BlockStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ExpressionStatement", () => {
+      test("allows expression statements when included", () => {
+        const code = `5`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents expression statements when not included", () => {
+        const code = `5`;
+        const allowedNodes: NodeType[] = ["LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ExpressionStatementNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("Expression restrictions", () => {
+    describe("LiteralExpression", () => {
+      test("allows literals when included", () => {
+        const code = `42`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents literals when not included", () => {
+        const code = `42`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("LiteralExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+
+      test("prevents all literal types", () => {
+        const testCases = [
+          { code: `True`, desc: "boolean True" },
+          { code: `False`, desc: "boolean False" },
+          { code: `None`, desc: "None" },
+          { code: `42`, desc: "number" },
+          { code: `"hello"`, desc: "string" },
+        ];
+
+        const allowedNodes: NodeType[] = ["ExpressionStatement"];
+
+        for (const { code, desc } of testCases) {
+          const { error } = interpret(code, { allowedNodes });
+          expect(error).toBeInstanceOf(SyntaxError);
+          expect(error?.type).toBe("LiteralExpressionNotAllowed");
+        }
+      });
+    });
+
+    describe("BinaryExpression", () => {
+      test("allows binary expressions when included", () => {
+        const code = `1 + 2`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "BinaryExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents binary expressions when not included", () => {
+        const code = `1 + 2`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("BinaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+
+      test("prevents all binary operators", () => {
+        const testCases = [
+          { code: `1 + 2`, op: "addition" },
+          { code: `1 - 2`, op: "subtraction" },
+          { code: `1 * 2`, op: "multiplication" },
+          { code: `1 / 2`, op: "division" },
+          { code: `1 < 2`, op: "less than" },
+          { code: `1 > 2`, op: "greater than" },
+          { code: `1 <= 2`, op: "less than or equal" },
+          { code: `1 >= 2`, op: "greater than or equal" },
+          { code: `1 == 2`, op: "equality" },
+          { code: `1 != 2`, op: "inequality" },
+          { code: `True and False`, op: "logical AND" },
+          { code: `True or False`, op: "logical OR" },
+        ];
+
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+
+        for (const { code, op } of testCases) {
+          const { error } = interpret(code, { allowedNodes });
+          expect(error).toBeInstanceOf(SyntaxError);
+          expect(error?.type).toBe("BinaryExpressionNotAllowed");
+        }
+      });
+    });
+
+    describe("UnaryExpression", () => {
+      test("allows unary expressions when included", () => {
+        const code = `-5`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "UnaryExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents unary expressions when not included", () => {
+        const code = `-5`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("UnaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+
+      test("prevents not operator", () => {
+        const code = `not True`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("UnaryExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("IdentifierExpression", () => {
+      test("allows identifiers when included", () => {
+        const code = `
+x = 5
+x
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "AssignmentStatement",
+          "ExpressionStatement",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents identifiers when not included", () => {
+        const code = `
+x = 5
+x
+        `.trim();
+        const allowedNodes: NodeType[] = ["AssignmentStatement", "ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("IdentifierExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("GroupingExpression", () => {
+      test("allows grouping when included", () => {
+        const code = `(5)`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "GroupingExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents grouping when not included", () => {
+        const code = `(5)`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("GroupingExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("ListExpression", () => {
+      test("allows lists when included", () => {
+        const code = `[1, 2, 3]`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "ListExpression", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents lists when not included", () => {
+        const code = `[1, 2, 3]`;
+        const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("ListExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+
+    describe("SubscriptExpression", () => {
+      test("allows subscript access when included", () => {
+        const code = `
+lst = [1, 2]
+lst[0]
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "AssignmentStatement",
+          "ExpressionStatement",
+          "ListExpression",
+          "SubscriptExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeNull();
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      test("prevents subscript access when not included", () => {
+        const code = `
+lst = [1, 2]
+lst[0]
+        `.trim();
+        const allowedNodes: NodeType[] = [
+          "AssignmentStatement",
+          "ExpressionStatement",
+          "ListExpression",
+          "IdentifierExpression",
+          "LiteralExpression",
+        ];
+        const { error, frames } = interpret(code, { allowedNodes });
+        expect(error).toBeInstanceOf(SyntaxError);
+        expect(error?.type).toBe("SubscriptExpressionNotAllowed");
+        expect(frames).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("Complex scenarios", () => {
+    test("allows only literals and expression statements", () => {
+      const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
+
+      // Should work
+      const { error: error1 } = interpret(`5`, { allowedNodes });
+      expect(error1).toBeNull();
+
+      // Should fail - needs assignment
+      const { error: error2 } = interpret(`x = 5`, { allowedNodes });
+      expect(error2?.type).toBe("AssignmentStatementNotAllowed");
+
+      // Should fail - needs binary expression
+      const { error: error3 } = interpret(`1 + 2`, { allowedNodes });
+      expect(error3?.type).toBe("BinaryExpressionNotAllowed");
+    });
+
+    test("allows basic arithmetic only", () => {
+      const allowedNodes: NodeType[] = [
+        "ExpressionStatement",
+        "LiteralExpression",
+        "BinaryExpression",
+        "GroupingExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(`(1 + 2) * 3`, { allowedNodes });
+      expect(error1).toBeNull();
+      expect(frames1.length).toBeGreaterThan(0);
+
+      // Should fail - needs assignment
+      const { error: error2 } = interpret(`x = 1 + 2`, { allowedNodes });
+      expect(error2?.type).toBe("AssignmentStatementNotAllowed");
+    });
+
+    test("allows variables but no control flow", () => {
+      const allowedNodes: NodeType[] = [
+        "AssignmentStatement",
+        "ExpressionStatement",
+        "IdentifierExpression",
+        "LiteralExpression",
+        "BinaryExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(
+        `
+x = 5
+x = x + 1
+x
+      `.trim(),
+        { allowedNodes }
+      );
+      expect(error1).toBeNull();
+      expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(6);
+
+      // Should fail - needs if statement
+      const { error: error2 } = interpret(
+        `
+x = 5
+if x > 0:
+    x = 10
+      `.trim(),
+        { allowedNodes }
+      );
+      expect(error2?.type).toBe("IfStatementNotAllowed");
+    });
+
+    test("allows control flow but no loops", () => {
+      const allowedNodes: NodeType[] = [
+        "AssignmentStatement",
+        "IfStatement",
+        "BlockStatement",
+        "ExpressionStatement",
+        "BinaryExpression",
+        "IdentifierExpression",
+        "LiteralExpression",
+      ];
+
+      // Should work
+      const { error: error1, frames: frames1 } = interpret(
+        `
+x = 5
+if x > 0:
+    x = 10
+      `.trim(),
+        { allowedNodes }
+      );
+      expect(error1).toBeNull();
+      expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(10);
+
+      // Should fail - needs for statement
+      const { error: error2 } = interpret(
+        `
+for i in [1, 2, 3]:
+    x = i
+      `.trim(),
+        { allowedNodes }
+      );
+      expect(error2?.type).toBe("ForInStatementNotAllowed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements AST node-level restrictions for both JavaScript and Python interpreters. This allows curriculum developers to restrict which language constructs students can use at different levels.

### JavaScript Implementation

- Added `NodeType` union type with all supported JavaScript AST nodes
- Added specific error types for each node restriction
- Implemented parser-level node checking
- Added comprehensive test suite

### Python Implementation

- Added `NodeType` union type with all 15 supported Python AST nodes
- Added 15 specific error types (one for each node restriction)
- Implemented parser-level node checking with early validation
- Added executor safety checks as defensive layer
- Refactored statement parsing to check types before parsing components
- Added comprehensive test suite with 39 test cases

### Shared Changes

- Cleaned up language index exports (only export `interpret()` and types)
- Exported `NodeType` and `LanguageFeatures` types for curriculum integration

### Technical Details

- Empty `allowedNodes` array means nothing is allowed
- `null` or `undefined` means all nodes are allowed (default behavior)
- Parser is the primary control point for restrictions
- Executor checks serve as a safety net
- Error messages are specific to each node type for educational clarity

### Testing

All tests pass including comprehensive test suites for both JavaScript and Python allowedNodes features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)