### PR TITLE
feat: Add external function support to Python interpreter

### DIFF
--- a/.context/evolution.md
+++ b/.context/evolution.md
@@ -139,3 +139,29 @@ When updating an interpreter to follow shared architecture:
 - Point-in-time documentation should be separated from current architecture guides
 
 This historical context helps understand architectural decisions but is not required for current development. Current patterns are documented in the main architecture files.
+
+## 2025-01-28: External Functions and Success Flag Standardization
+
+### Changes Made
+
+1. **External Function Support Enhancement**
+   - Added `PyCallable` and `JSCallable` classes extending JikiObject
+   - External functions now stored as callable objects in environment
+   - Removed separate external function registries
+   - Added `FunctionExecutionError` for when external functions throw
+   - Added comprehensive tests for error scenarios
+
+2. **Success Flag Standardization**
+   - Fixed JavaScript executor to return `success: false` when error frames exist
+   - Previously JavaScript always returned `success: true` regardless of errors
+   - Now both Python and JavaScript use: `success: !this.frames.find(f => f.status === "ERROR")`
+   - Updated ~20 test files to expect correct success values
+
+3. **Test Setup Simplification**
+   - Global test setup (`tests/setup.ts`) already sets all interpreters to "system" language
+   - Removed redundant `changeLanguage("system")` calls from individual test files
+   - This simplifies test maintenance and reduces boilerplate
+
+### Impact
+
+These changes ensure consistent behavior between JavaScript and Python interpreters, particularly around error handling and external function integration. The success flag fix was critical for proper UI integration, as the UI relies on this flag to determine if execution completed successfully.

--- a/.context/shared/common-issues.md
+++ b/.context/shared/common-issues.md
@@ -22,6 +22,12 @@ This document outlines the most common mistakes developers make when working on 
 
 **✅ CORRECT**: All execution must use `executeFrame()` wrapper.
 
+### ❌ Success Flag Always True
+
+**WRONG**: Hardcoding `success: true` in executor result regardless of error frames.
+
+**✅ CORRECT**: Set `success: !this.frames.find(f => f.status === "ERROR")` - success is false if any error frames exist.
+
 ## Error Message Format Issues
 
 ### ❌ Wrong System Message Format
@@ -32,9 +38,9 @@ This document outlines the most common mistakes developers make when working on 
 
 ### ❌ Missing Language Configuration in Tests
 
-**WRONG**: Tests without `changeLanguage("system")` setup get English messages.
+**WRONG**: Adding `changeLanguage("system")` in individual test files when it's already configured globally.
 
-**✅ CORRECT**: Runtime error tests MUST use system language configuration.
+**✅ CORRECT**: Global test setup (`tests/setup.ts`) already sets all interpreters to use "system" language. Individual test files DO NOT need to call `changeLanguage("system")`.
 
 ## Location Tracking Problems
 

--- a/TODO.md
+++ b/TODO.md
@@ -93,6 +93,7 @@ For everything in here, base your work in the JikiScript interpreter.
 
 - [x] Add a for in loop. Look at the JikiScript implementation.
 - [x] Add proper descriptions support to python liek we have in JikiScript. None of this "generateDescription" method nonsense. Proper describers that work properly like JikiScript.
+- [x] Add the ability to call external functions. Look at the JavaScript implementation of this. We'll use a standard CallExpression but we'll check to see if the function is external and use it if so. We need to keep the format the same in terms of using ExecutionContext etc. The same external functions contract needs to apply to all three languages and should be made generic.
 - [ ] Add a while loop. Look at the JavaScript implementation.
 - [ ] Add fstrings
 - [ ] Don't allow statements that don't actually do anything. For example, a statement that is just a variable. Or a grouping expression that doesn't have assignment. Add a TOOD that you will need to modify this for calling functions (which should just be allowed by themselves) later. Look at how this works in JikiScript as there is a specific type for it.

--- a/src/javascript/executor.ts
+++ b/src/javascript/executor.ts
@@ -169,7 +169,7 @@ export class Executor {
     return {
       frames: this.frames,
       error: null, // Always null - runtime errors are in frames
-      success: true, // Always true - runtime errors don't affect success
+      success: !this.frames.find(f => f.status === "ERROR"),
     };
   }
 

--- a/src/javascript/executor.ts
+++ b/src/javascript/executor.ts
@@ -31,6 +31,7 @@ import { translate } from "./translator";
 import { TIME_SCALE_FACTOR, type Frame, type FrameExecutionStatus } from "../shared/frames";
 import { type ExecutionContext as SharedExecutionContext, type ExternalFunction } from "../shared/interfaces";
 import { createBaseExecutionContext } from "../shared/executionContext";
+import type { EvaluationContext } from "./interpreter";
 import { describeFrame } from "./frameDescribers";
 import cloneDeep from "lodash.clonedeep";
 
@@ -109,21 +110,20 @@ export class Executor {
 
   constructor(
     private readonly sourceCode: string,
-    languageFeatures?: LanguageFeatures,
-    externalFunctions?: ExternalFunction[]
+    context: EvaluationContext
   ) {
     this.environment = new Environment();
     this.languageFeatures = {
       allowShadowing: false, // Default to false (shadowing disabled)
       allowTypeCoercion: false, // Default to false (type coercion disabled)
       enforceStrictEquality: true, // Default to true (strict equality required)
-      ...languageFeatures,
+      ...context.languageFeatures,
     };
 
     // Store external functions in a map for fast lookup
     this.externalFunctions = new Map();
-    if (externalFunctions) {
-      for (const func of externalFunctions) {
+    if (context.externalFunctions) {
+      for (const func of context.externalFunctions) {
         this.externalFunctions.set(func.name, func);
       }
     }

--- a/src/javascript/executor/executeIdentifierExpression.ts
+++ b/src/javascript/executor/executeIdentifierExpression.ts
@@ -1,39 +1,21 @@
 import type { Executor } from "../executor";
 import type { IdentifierExpression } from "../expression";
 import type { EvaluationResultIdentifierExpression } from "../evaluation-result";
-import { JSBoolean } from "../jsObjects";
 
 export function executeIdentifierExpression(
   executor: Executor,
   expression: IdentifierExpression
 ): EvaluationResultIdentifierExpression {
-  // First check if it's a variable
   const value = executor.environment.get(expression.name.lexeme);
 
-  if (value !== undefined) {
-    return {
-      type: "IdentifierExpression",
-      name: expression.name.lexeme,
-      jikiObject: value,
-      immutableJikiObject: value.clone(),
-    };
+  if (value === undefined) {
+    executor.error("VariableNotDeclared", expression.location, { name: expression.name.lexeme });
   }
 
-  // Then check if it's an external function
-  const externalFunction = executor.getExternalFunction(expression.name.lexeme);
-  if (externalFunction !== undefined) {
-    // For function identifiers, we return a special result with functionName
-    // The actual jikiObject is a placeholder since functions aren't values yet
-    const placeholder = new JSBoolean(true);
-    return {
-      type: "IdentifierExpression",
-      name: expression.name.lexeme,
-      jikiObject: placeholder,
-      immutableJikiObject: placeholder,
-      functionName: expression.name.lexeme, // Add function name for call expression
-    };
-  }
-
-  // Neither variable nor function found
-  executor.error("VariableNotDeclared", expression.location, { name: expression.name.lexeme });
+  return {
+    type: "IdentifierExpression",
+    name: expression.name.lexeme,
+    jikiObject: value,
+    immutableJikiObject: value.clone(),
+  };
 }

--- a/src/javascript/functions.ts
+++ b/src/javascript/functions.ts
@@ -1,0 +1,37 @@
+import type { Arity, ExecutionContext } from "../shared/interfaces";
+import { JikiObject } from "./jikiObjects";
+
+export interface Callable {
+  arity: Arity | undefined;
+  call: (context: ExecutionContext, args: any[]) => any;
+}
+
+export function isCallable(obj: any): obj is Callable {
+  return obj instanceof Object && "call" in obj;
+}
+
+export class JSCallable extends JikiObject {
+  constructor(
+    public readonly name: string,
+    public readonly arity: Arity | undefined,
+    private readonly func: Function
+  ) {
+    super("callable");
+  }
+
+  get value(): Function {
+    return this.func;
+  }
+
+  call(context: ExecutionContext, args: any[]): any {
+    return this.func(context, ...args);
+  }
+
+  clone(): JSCallable {
+    return new JSCallable(this.name, this.arity, this.func);
+  }
+
+  toString(): string {
+    return `function ${this.name}() { [native code] }`;
+  }
+}

--- a/src/javascript/functions.ts
+++ b/src/javascript/functions.ts
@@ -7,7 +7,7 @@ export interface Callable {
 }
 
 export function isCallable(obj: any): obj is Callable {
-  return obj instanceof Object && "call" in obj;
+  return obj instanceof Object && "arity" in obj && "call" in obj;
 }
 
 export class JSCallable extends JikiObject {

--- a/src/javascript/interpreter.ts
+++ b/src/javascript/interpreter.ts
@@ -18,13 +18,25 @@ export interface InterpretResult {
   success: boolean;
 }
 
-export function interpret(sourceCode: string, context: EvaluationContext = {}): InterpretResult {
+export function interpret(
+  sourceCode: string,
+  contextOrFeatures: EvaluationContext | LanguageFeatures = {}
+): InterpretResult {
+  // Support both old and new signatures for backward compatibility
+  let context: EvaluationContext;
+  if ("languageFeatures" in contextOrFeatures || "externalFunctions" in contextOrFeatures) {
+    context = contextOrFeatures;
+  } else {
+    // Old style: just language features
+    context = { languageFeatures: contextOrFeatures as LanguageFeatures };
+  }
+
   try {
     // Parse the source code (compilation step)
-    const statements = parse(sourceCode, context.languageFeatures);
+    const statements = parse(sourceCode, context);
 
     // Execute statements
-    const executor = new Executor(sourceCode, context.languageFeatures, context.externalFunctions);
+    const executor = new Executor(sourceCode, context);
     const result = executor.execute(statements);
 
     return {

--- a/src/javascript/interpreter.ts
+++ b/src/javascript/interpreter.ts
@@ -18,19 +18,7 @@ export interface InterpretResult {
   success: boolean;
 }
 
-export function interpret(
-  sourceCode: string,
-  contextOrFeatures: EvaluationContext | LanguageFeatures = {}
-): InterpretResult {
-  // Support both old and new signatures for backward compatibility
-  let context: EvaluationContext;
-  if ("languageFeatures" in contextOrFeatures || "externalFunctions" in contextOrFeatures) {
-    context = contextOrFeatures;
-  } else {
-    // Old style: just language features
-    context = { languageFeatures: contextOrFeatures as LanguageFeatures };
-  }
-
+export function interpret(sourceCode: string, context: EvaluationContext = {}): InterpretResult {
   try {
     // Parse the source code (compilation step)
     const statements = parse(sourceCode, context);

--- a/src/javascript/locales/en/translation.json
+++ b/src/javascript/locales/en/translation.json
@@ -30,16 +30,17 @@
       "UnterminatedString": "Did you forget to add end quote?"
     },
     "runtime": {
+      "ArgumentError": "{{message}}",
+      "FunctionExecutionError": "Error executing function '{{function}}': {{message}}",
+      "IndexOutOfRange": "Index {{index}} is out of range. Array has {{length}} elements.",
       "InvalidBinaryExpression": "Invalid operation between values.",
       "InvalidUnaryExpression": "Invalid unary operation.",
-      "UnsupportedOperation": "This operation is not supported.",
-      "VariableNotDeclared": "The variable '{{name}}' has not been declared.",
+      "PropertyNotFound": "Property '{{property}}' does not exist on arrays.",
       "ShadowingDisabled": "Variable shadowing is disabled. The variable '{{name}}' is already declared in an outer scope.",
       "TruthinessDisabled": "Only boolean values are allowed in conditions, but got '{{value}}'.",
-      "IndexOutOfRange": "Index {{index}} is out of range. Array has {{length}} elements.",
       "TypeError": "{{message}}",
-      "PropertyNotFound": "Property '{{property}}' does not exist on arrays.",
-      "ArgumentError": "{{message}}"
+      "UnsupportedOperation": "This operation is not supported.",
+      "VariableNotDeclared": "The variable '{{name}}' has not been declared."
     }
   }
 }

--- a/src/javascript/locales/system/translation.json
+++ b/src/javascript/locales/system/translation.json
@@ -30,16 +30,17 @@
       "UnterminatedString": "Did you forget to add end quote?"
     },
     "runtime": {
+      "ArgumentError": "ArgumentError: {{message}}",
+      "FunctionExecutionError": "FunctionExecutionError: function: {{function}}: message: {{message}}",
+      "IndexOutOfRange": "IndexOutOfRange: index: {{index}}: length: {{length}}",
       "InvalidBinaryExpression": "InvalidBinaryExpression",
       "InvalidUnaryExpression": "InvalidUnaryExpression",
-      "UnsupportedOperation": "UnsupportedOperation",
-      "VariableNotDeclared": "VariableNotDeclared: name: {{name}}",
+      "PropertyNotFound": "PropertyNotFound: property: {{property}}",
       "ShadowingDisabled": "ShadowingDisabled: name: {{name}}",
       "TruthinessDisabled": "TruthinessDisabled: value: {{value}}",
-      "IndexOutOfRange": "IndexOutOfRange: index: {{index}}: length: {{length}}",
       "TypeError": "TypeError: {{message}}",
-      "PropertyNotFound": "PropertyNotFound: property: {{property}}",
-      "ArgumentError": "ArgumentError: {{message}}"
+      "UnsupportedOperation": "UnsupportedOperation",
+      "VariableNotDeclared": "VariableNotDeclared: name: {{name}}"
     }
   }
 }

--- a/src/javascript/parser.ts
+++ b/src/javascript/parser.ts
@@ -36,7 +36,7 @@ export class Parser {
   private tokens: Token[] = [];
   private readonly languageFeatures: LanguageFeatures;
 
-  constructor(context: EvaluationContext) {
+  constructor(context: EvaluationContext = {}) {
     this.scanner = new Scanner();
     this.languageFeatures = context.languageFeatures || {};
   }

--- a/src/javascript/parser.ts
+++ b/src/javascript/parser.ts
@@ -28,6 +28,7 @@ import {
 import { type Token, type TokenType } from "./token";
 import { translate } from "./translator";
 import type { LanguageFeatures, NodeType } from "./interfaces";
+import type { EvaluationContext } from "./interpreter";
 
 export class Parser {
   private readonly scanner: Scanner;
@@ -35,9 +36,9 @@ export class Parser {
   private tokens: Token[] = [];
   private readonly languageFeatures: LanguageFeatures;
 
-  constructor(languageFeatures?: LanguageFeatures) {
+  constructor(context: EvaluationContext) {
     this.scanner = new Scanner();
-    this.languageFeatures = languageFeatures || {};
+    this.languageFeatures = context.languageFeatures || {};
   }
 
   private isNodeAllowed(nodeType: NodeType): boolean {
@@ -853,6 +854,6 @@ export class Parser {
   }
 }
 
-export function parse(sourceCode: string, languageFeatures?: LanguageFeatures): Statement[] {
-  return new Parser(languageFeatures).parse(sourceCode);
+export function parse(sourceCode: string, context: EvaluationContext = {}): Statement[] {
+  return new Parser(context).parse(sourceCode);
 }

--- a/src/python/describers/describeCallExpression.ts
+++ b/src/python/describers/describeCallExpression.ts
@@ -1,0 +1,38 @@
+import type { EvaluationResultCallExpression } from "../evaluation-result";
+import type { CallExpression } from "../expression";
+import { describeExpression } from "./describeSteps";
+import { formatPyObject } from "./helpers";
+
+export function describeCallExpression(expression: CallExpression, result: EvaluationResultCallExpression): string[] {
+  const steps: string[] = [];
+
+  // First, describe evaluation of all arguments
+  for (let i = 0; i < result.args.length; i++) {
+    const argResult = result.args[i];
+    const argSteps = describeExpression(expression.args[i], argResult as any, { functionDescriptions: {} });
+    if (argSteps.length > 0) {
+      steps.push(...argSteps);
+    }
+  }
+
+  // Build arguments description
+  const argValues = result.args.map(arg => {
+    return formatPyObject(arg.jikiObject);
+  });
+
+  // Then describe the function call
+  if (argValues.length === 0) {
+    steps.push(`<li>Python used the <code>${result.functionName}</code> function.</li>`);
+  } else if (argValues.length === 1) {
+    steps.push(
+      `<li>Python used the <code>${result.functionName}</code> function with <code>${argValues[0]}</code>.</li>`
+    );
+  } else {
+    const lastArg = argValues.pop();
+    steps.push(
+      `<li>Python used the <code>${result.functionName}</code> function with <code>${argValues.join("</code>, <code>")}</code> and <code>${lastArg}</code>.</li>`
+    );
+  }
+
+  return steps;
+}

--- a/src/python/describers/describeExpressionStatement.ts
+++ b/src/python/describers/describeExpressionStatement.ts
@@ -10,9 +10,19 @@ export function describeExpressionStatement(frame: FrameWithResult, context: Des
   const frameResult = frame.result as EvaluationResultExpressionStatement;
   const value = formatPyObject(frameResult.immutableJikiObject);
 
-  const result = `<p>This expression evaluated to <code>${value}</code>.</p>`;
-  let steps = describeExpression(statement.expression, frameResult.expression, context);
-  steps = [...steps, `<li>Python evaluated this expression and got <code>${value}</code>.</li>`];
+  // Check if this is a CallExpression for better description
+  let result: string;
+  let steps: string[];
+
+  if (frameResult.expression.type === "CallExpression") {
+    const callResult = frameResult.expression as any;
+    result = `<p>Python used the <code>${callResult.functionName}</code> function and returned <code>${value}</code>.</p>`;
+    steps = describeExpression(statement.expression, frameResult.expression, context);
+  } else {
+    result = `<p>This expression evaluated to <code>${value}</code>.</p>`;
+    steps = describeExpression(statement.expression, frameResult.expression, context);
+    steps = [...steps, `<li>Python evaluated this expression and got <code>${value}</code>.</li>`];
+  }
 
   return {
     result,

--- a/src/python/describers/describeSteps.ts
+++ b/src/python/describers/describeSteps.ts
@@ -4,6 +4,7 @@ import type { DescriptionContext } from "../../shared/frames";
 import { describeBinaryExpression } from "./describeBinaryExpression";
 import { describeUnaryExpression } from "./describeUnaryExpression";
 import { describeSubscriptExpression } from "./describeSubscriptExpression";
+import { describeCallExpression } from "./describeCallExpression";
 import { formatPyObject } from "./helpers";
 
 export function describeExpression(
@@ -20,6 +21,9 @@ export function describeExpression(
 
     case "SubscriptExpression":
       return describeSubscriptExpression(expression, result as any);
+
+    case "CallExpression":
+      return describeCallExpression(expression as any, result as any);
 
     case "IdentifierExpression": {
       const identResult = result as any;

--- a/src/python/error.ts
+++ b/src/python/error.ts
@@ -41,6 +41,7 @@ export type SyntaxErrorType =
   | "IdentifierExpressionNotAllowed"
   | "ListExpressionNotAllowed"
   | "SubscriptExpressionNotAllowed"
+  | "CallExpressionNotAllowed"
   | "ExpressionStatementNotAllowed"
   | "PrintStatementNotAllowed"
   | "AssignmentStatementNotAllowed"

--- a/src/python/evaluation-result.ts
+++ b/src/python/evaluation-result.ts
@@ -46,6 +46,7 @@ export interface EvaluationResultExpressionStatement {
 export interface EvaluationResultIdentifierExpression {
   type: "IdentifierExpression";
   name: string;
+  functionName?: string; // For external function lookup
   jikiObject: JikiObject;
   immutableJikiObject: JikiObject;
 }
@@ -62,6 +63,14 @@ export interface EvaluationResultSubscriptExpression {
   type: "SubscriptExpression";
   object: EvaluationResultExpression;
   index: EvaluationResultExpression;
+  jikiObject: JikiObject;
+  immutableJikiObject: JikiObject;
+}
+
+export interface EvaluationResultCallExpression {
+  type: "CallExpression";
+  functionName: string;
+  args: EvaluationResult[];
   jikiObject: JikiObject;
   immutableJikiObject: JikiObject;
 }

--- a/src/python/executor/executeCallExpression.ts
+++ b/src/python/executor/executeCallExpression.ts
@@ -1,0 +1,115 @@
+import type { Executor } from "../executor";
+import { RuntimeError } from "../executor";
+import type { CallExpression } from "../expression";
+import type {
+  EvaluationResult,
+  EvaluationResultIdentifierExpression,
+  EvaluationResultCallExpression,
+} from "../evaluation-result";
+import { createPyObject } from "../jikiObjects";
+import type { JikiObject } from "../jikiObjects";
+import type { Arity } from "../../shared/interfaces";
+
+export function executeCallExpression(executor: Executor, expression: CallExpression): EvaluationResultCallExpression {
+  // Evaluate the callee
+  const calleeResult = executor.evaluate(expression.callee);
+
+  // For now, we only support calling external functions by identifier
+  // Check if the result is an identifier with a function name
+  const identifierResult = calleeResult as EvaluationResultIdentifierExpression;
+  if (!identifierResult.functionName) {
+    throw new RuntimeError(`TypeError: ${expression.callee.type} is not callable`, expression.location, "TypeError", {
+      callee: expression.callee.type,
+    });
+  }
+
+  // Look up the external function
+  const externalFunction = executor.getExternalFunction(identifierResult.functionName);
+  if (!externalFunction) {
+    throw new RuntimeError(
+      `FunctionNotFound: name: ${identifierResult.functionName}`,
+      expression.location,
+      "FunctionNotFound",
+      { name: identifierResult.functionName }
+    );
+  }
+
+  // Evaluate arguments and store both the results and JikiObjects
+  const argResults: EvaluationResult[] = [];
+  const argJikiObjects: JikiObject[] = [];
+  for (const arg of expression.args) {
+    const argResult = executor.evaluate(arg);
+    argResults.push(argResult);
+    argJikiObjects.push(argResult.jikiObject);
+  }
+
+  // Check arity
+  checkArity(executor, externalFunction.arity, argJikiObjects.length, expression, identifierResult.functionName);
+
+  // Call the external function
+  // External functions receive ExecutionContext as first parameter, then the arguments
+  const executionContext = executor.getExecutionContext();
+
+  try {
+    // Convert JikiObjects to values for the external function
+    const argValues = argJikiObjects.map(arg => arg.value);
+    const result = externalFunction.func(executionContext, ...argValues);
+
+    // Convert the result back to a PyObject
+    const pyResult = createPyObject(result);
+
+    return {
+      type: "CallExpression",
+      jikiObject: pyResult,
+      immutableJikiObject: pyResult.clone(),
+      functionName: identifierResult.functionName,
+      args: argResults, // Store full evaluation results for describers
+    };
+  } catch (error) {
+    // Handle any errors from the external function
+    if (error instanceof Error) {
+      throw new RuntimeError(
+        `FunctionExecutionError: function: ${identifierResult.functionName}: message: ${error.message}`,
+        expression.location,
+        "TypeError",
+        { function: identifierResult.functionName, message: error.message }
+      );
+    }
+    throw error;
+  }
+}
+
+function checkArity(
+  executor: Executor,
+  arity: Arity | undefined,
+  argCount: number,
+  expression: CallExpression,
+  functionName: string
+): void {
+  if (!arity) {
+    // If arity is not specified, accept any number of arguments
+    return;
+  }
+
+  const [minArity, maxArity] = typeof arity === "number" ? [arity, arity] : arity;
+
+  if (argCount < minArity || argCount > maxArity) {
+    const arityMessage =
+      minArity === maxArity
+        ? `${minArity}`
+        : maxArity === Infinity
+          ? `at least ${minArity}`
+          : `between ${minArity} and ${maxArity}`;
+
+    throw new RuntimeError(
+      `InvalidNumberOfArguments: function: ${functionName}: expected: ${arityMessage}: got: ${argCount}`,
+      expression.location,
+      "InvalidNumberOfArguments",
+      {
+        function: functionName,
+        expected: arityMessage,
+        got: argCount,
+      }
+    );
+  }
+}

--- a/src/python/executor/executeCallExpression.ts
+++ b/src/python/executor/executeCallExpression.ts
@@ -1,38 +1,26 @@
 import type { Executor } from "../executor";
 import { RuntimeError } from "../executor";
 import type { CallExpression } from "../expression";
-import type {
-  EvaluationResult,
-  EvaluationResultIdentifierExpression,
-  EvaluationResultCallExpression,
-} from "../evaluation-result";
+import type { EvaluationResult, EvaluationResultCallExpression } from "../evaluation-result";
 import { createPyObject } from "../jikiObjects";
 import type { JikiObject } from "../jikiObjects";
 import type { Arity } from "../../shared/interfaces";
+import { isCallable, type PyCallable } from "../functions";
 
 export function executeCallExpression(executor: Executor, expression: CallExpression): EvaluationResultCallExpression {
   // Evaluate the callee
   const calleeResult = executor.evaluate(expression.callee);
+  const calleeValue = calleeResult.jikiObject;
 
-  // For now, we only support calling external functions by identifier
-  // Check if the result is an identifier with a function name
-  const identifierResult = calleeResult as EvaluationResultIdentifierExpression;
-  if (!identifierResult.functionName) {
+  // Check if the value is callable
+  if (!isCallable(calleeValue)) {
     throw new RuntimeError(`TypeError: ${expression.callee.type} is not callable`, expression.location, "TypeError", {
       callee: expression.callee.type,
     });
   }
 
-  // Look up the external function
-  const externalFunction = executor.getExternalFunction(identifierResult.functionName);
-  if (!externalFunction) {
-    throw new RuntimeError(
-      `FunctionNotFound: name: ${identifierResult.functionName}`,
-      expression.location,
-      "FunctionNotFound",
-      { name: identifierResult.functionName }
-    );
-  }
+  // Type assertion since we know it's a PyCallable from our implementation
+  const callable = calleeValue as PyCallable;
 
   // Evaluate arguments and store both the results and JikiObjects
   const argResults: EvaluationResult[] = [];
@@ -44,16 +32,15 @@ export function executeCallExpression(executor: Executor, expression: CallExpres
   }
 
   // Check arity
-  checkArity(executor, externalFunction.arity, argJikiObjects.length, expression, identifierResult.functionName);
+  checkArity(executor, callable.arity, argJikiObjects.length, expression, callable.name);
 
-  // Call the external function
-  // External functions receive ExecutionContext as first parameter, then the arguments
+  // Call the function
   const executionContext = executor.getExecutionContext();
 
   try {
-    // Convert JikiObjects to values for the external function
+    // Convert JikiObjects to values for the function
     const argValues = argJikiObjects.map(arg => arg.value);
-    const result = externalFunction.func(executionContext, ...argValues);
+    const result = callable.call(executionContext, argValues);
 
     // Convert the result back to a PyObject
     const pyResult = createPyObject(result);
@@ -62,17 +49,17 @@ export function executeCallExpression(executor: Executor, expression: CallExpres
       type: "CallExpression",
       jikiObject: pyResult,
       immutableJikiObject: pyResult.clone(),
-      functionName: identifierResult.functionName,
+      functionName: callable.name,
       args: argResults, // Store full evaluation results for describers
     };
   } catch (error) {
     // Handle any errors from the external function
     if (error instanceof Error) {
       throw new RuntimeError(
-        `FunctionExecutionError: function: ${identifierResult.functionName}: message: ${error.message}`,
+        `FunctionExecutionError: function: ${callable.name}: message: ${error.message}`,
         expression.location,
-        "TypeError",
-        { function: identifierResult.functionName, message: error.message }
+        "FunctionExecutionError",
+        { function: callable.name, message: error.message }
       );
     }
     throw error;

--- a/src/python/executor/executeIdentifierExpression.ts
+++ b/src/python/executor/executeIdentifierExpression.ts
@@ -1,16 +1,16 @@
 import type { Executor } from "../executor";
 import { RuntimeError } from "../executor";
 import type { IdentifierExpression } from "../expression";
-import type { EvaluationResult } from "../evaluation-result";
+import type { EvaluationResultIdentifierExpression } from "../evaluation-result";
 import { translate } from "../translator";
 
-export function executeIdentifierExpression(executor: Executor, expression: IdentifierExpression): EvaluationResult {
+export function executeIdentifierExpression(
+  executor: Executor,
+  expression: IdentifierExpression
+): EvaluationResultIdentifierExpression {
   const value = executor.environment.get(expression.name.lexeme);
 
-  // Check if this is an external function name
-  const externalFunction = executor.getExternalFunction(expression.name.lexeme);
-
-  if (value === undefined && !externalFunction) {
+  if (value === undefined) {
     throw new RuntimeError(
       translate(`error.runtime.UndefinedVariable`, { name: expression.name.lexeme }),
       expression.location,
@@ -18,29 +18,10 @@ export function executeIdentifierExpression(executor: Executor, expression: Iden
     );
   }
 
-  // If it's an external function, mark it as such for CallExpression
-  if (externalFunction) {
-    return {
-      type: "IdentifierExpression",
-      name: expression.name.lexeme,
-      functionName: expression.name.lexeme, // Mark as function name for CallExpression
-      jikiObject: value || {
-        type: "function",
-        value: expression.name.lexeme,
-        clone: () => ({ type: "function", value: expression.name.lexeme }),
-      },
-      immutableJikiObject: value?.clone() || {
-        type: "function",
-        value: expression.name.lexeme,
-        clone: () => ({ type: "function", value: expression.name.lexeme }),
-      },
-    } as any;
-  }
-
   return {
     type: "IdentifierExpression",
     name: expression.name.lexeme,
-    jikiObject: value!,
-    immutableJikiObject: value!.clone(),
-  } as any;
+    jikiObject: value,
+    immutableJikiObject: value.clone(),
+  };
 }

--- a/src/python/expression.ts
+++ b/src/python/expression.ts
@@ -94,3 +94,16 @@ export class SubscriptExpression extends Expression {
     return [this.object, this.index];
   }
 }
+
+export class CallExpression extends Expression {
+  constructor(
+    public callee: Expression,
+    public args: Expression[],
+    public location: Location
+  ) {
+    super("CallExpression");
+  }
+  public children() {
+    return [this.callee, ...this.args];
+  }
+}

--- a/src/python/functions.ts
+++ b/src/python/functions.ts
@@ -7,7 +7,7 @@ export interface Callable {
 }
 
 export function isCallable(obj: any): obj is Callable {
-  return obj instanceof Object && "call" in obj;
+  return obj instanceof Object && "arity" in obj && "call" in obj;
 }
 
 export class PyCallable extends JikiObject {

--- a/src/python/functions.ts
+++ b/src/python/functions.ts
@@ -1,0 +1,37 @@
+import type { Arity, ExecutionContext } from "../shared/interfaces";
+import { JikiObject } from "./jikiObjects";
+
+export interface Callable {
+  arity: Arity | undefined;
+  call: (context: ExecutionContext, args: any[]) => any;
+}
+
+export function isCallable(obj: any): obj is Callable {
+  return obj instanceof Object && "call" in obj;
+}
+
+export class PyCallable extends JikiObject {
+  constructor(
+    public readonly name: string,
+    public readonly arity: Arity | undefined,
+    private readonly func: Function
+  ) {
+    super("callable");
+  }
+
+  get value(): Function {
+    return this.func;
+  }
+
+  call(context: ExecutionContext, args: any[]): any {
+    return this.func(context, ...args);
+  }
+
+  clone(): PyCallable {
+    return new PyCallable(this.name, this.arity, this.func);
+  }
+
+  toString(): string {
+    return `<function ${this.name}>`;
+  }
+}

--- a/src/python/interfaces.ts
+++ b/src/python/interfaces.ts
@@ -8,6 +8,7 @@ export type NodeType =
   | "IdentifierExpression"
   | "ListExpression"
   | "SubscriptExpression"
+  | "CallExpression"
   // Statements
   | "ExpressionStatement"
   | "PrintStatement"

--- a/src/python/interpreter.ts
+++ b/src/python/interpreter.ts
@@ -20,18 +20,9 @@ export interface InterpretResult {
 
 export function interpret(
   sourceCode: string,
-  contextOrFeatures: EvaluationContext | LanguageFeatures = {},
+  context: EvaluationContext = {},
   fileName: string = "python-script"
 ): InterpretResult {
-  // Support both old and new signatures for backward compatibility
-  let context: EvaluationContext;
-  if ("languageFeatures" in contextOrFeatures || "externalFunctions" in contextOrFeatures) {
-    context = contextOrFeatures;
-  } else {
-    // Old style: just language features
-    context = { languageFeatures: contextOrFeatures as LanguageFeatures };
-  }
-
   try {
     // Parse the source code (compilation step)
     const parser = new Parser(fileName, context);

--- a/src/python/locales/en/translation.json
+++ b/src/python/locales/en/translation.json
@@ -16,6 +16,7 @@
       "UnterminatedString": "Unterminated string literal. Make sure to close your string quotes."
     },
     "runtime": {
+      "FunctionExecutionError": "Error executing function '{{function}}': {{message}}",
       "InvalidBinaryExpression": "Invalid binary operation between these values.",
       "InvalidUnaryExpression": "Invalid unary operation on this value.",
       "TruthinessDisabled": "Cannot use {{value}} as a boolean value. Only boolean values are allowed in conditions when truthiness is disabled.",

--- a/src/python/locales/system/translation.json
+++ b/src/python/locales/system/translation.json
@@ -16,6 +16,7 @@
       "UnterminatedString": "UnterminatedString"
     },
     "runtime": {
+      "FunctionExecutionError": "FunctionExecutionError: function: {{function}}: message: {{message}}",
       "InvalidBinaryExpression": "InvalidBinaryExpression",
       "InvalidUnaryExpression": "InvalidUnaryExpression",
       "TruthinessDisabled": "TruthinessDisabled: value: {{value}}",

--- a/src/python/parser.ts
+++ b/src/python/parser.ts
@@ -34,7 +34,7 @@ export class Parser {
 
   constructor(
     private readonly fileName: string,
-    context: EvaluationContext
+    context: EvaluationContext = {}
   ) {
     this.scanner = new Scanner(fileName);
     this.languageFeatures = context.languageFeatures || {};

--- a/tests/javascript/array-assignment.test.ts
+++ b/tests/javascript/array-assignment.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
-import { changeLanguage } from "../../src/javascript/translator";
 
 // Type for frames augmented in test environment
 interface TestFrame {
@@ -172,7 +171,6 @@ describe("JavaScript - Array Element Assignment", () => {
         x[0] = 10;
       `;
 
-      changeLanguage("system");
       const result = interpret(sourceCode);
       expect(result.error).toBeNull();
       expect(result.frames.length).toBe(2); // Should have 2 frames: variable declaration and error
@@ -188,7 +186,6 @@ describe("JavaScript - Array Element Assignment", () => {
         arr["foo"] = 10;
       `;
 
-      changeLanguage("system");
       const result = interpret(sourceCode);
       expect(result.error).toBeNull();
       expect(result.frames.length).toBe(2);
@@ -204,7 +201,6 @@ describe("JavaScript - Array Element Assignment", () => {
         arr[1.5] = 10;
       `;
 
-      changeLanguage("system");
       const result = interpret(sourceCode);
       expect(result.error).toBeNull();
       expect(result.frames.length).toBe(2);
@@ -220,7 +216,6 @@ describe("JavaScript - Array Element Assignment", () => {
         arr[-1] = 10;
       `;
 
-      changeLanguage("system");
       const result = interpret(sourceCode);
       expect(result.error).toBeNull();
       expect(result.frames.length).toBe(2);
@@ -236,7 +231,6 @@ describe("JavaScript - Array Element Assignment", () => {
         arr[1][0] = 5;
       `;
 
-      changeLanguage("system");
       const result = interpret(sourceCode);
       expect(result.error).toBeNull();
       expect(result.frames.length).toBe(2);

--- a/tests/javascript/arrays.test.ts
+++ b/tests/javascript/arrays.test.ts
@@ -1,6 +1,5 @@
 import { test, expect, describe } from "vitest";
 import { interpret } from "../../src/javascript/interpreter";
-import { changeLanguage } from "../../src/javascript/translator";
 
 // Type for frames augmented in test environment
 interface TestFrame {
@@ -289,14 +288,13 @@ describe("JavaScript Arrays", () => {
     });
 
     test("index out of bounds - negative", async () => {
-      await changeLanguage("system");
       const code = `
         let arr = [10, 20, 30];
         let value = arr[-1];
       `;
       const result = interpret(code);
 
-      expect(result.success).toBe(true); // Runtime errors don't affect success
+      expect(result.success).toBe(false); // Runtime errors don't affect success
       expect(result.frames.length).toBe(2);
 
       const frame = result.frames[1] as TestFrame;
@@ -305,14 +303,13 @@ describe("JavaScript Arrays", () => {
     });
 
     test("non-numeric index", async () => {
-      await changeLanguage("system");
       const code = `
         let arr = [10, 20, 30];
         let value = arr["hello"];
       `;
       const result = interpret(code);
 
-      expect(result.success).toBe(true); // Runtime errors don't affect success
+      expect(result.success).toBe(false); // Runtime errors don't affect success
       expect(result.frames.length).toBe(2);
 
       const frame = result.frames[1] as TestFrame;
@@ -321,14 +318,13 @@ describe("JavaScript Arrays", () => {
     });
 
     test("non-integer index", async () => {
-      await changeLanguage("system");
       const code = `
         let arr = [10, 20, 30];
         let value = arr[1.5];
       `;
       const result = interpret(code);
 
-      expect(result.success).toBe(true); // Runtime errors don't affect success
+      expect(result.success).toBe(false); // Runtime errors don't affect success
       expect(result.frames.length).toBe(2);
 
       const frame = result.frames[1] as TestFrame;
@@ -337,14 +333,13 @@ describe("JavaScript Arrays", () => {
     });
 
     test("accessing non-array", async () => {
-      await changeLanguage("system");
       const code = `
         let notArray = 42;
         let value = notArray[0];
       `;
       const result = interpret(code);
 
-      expect(result.success).toBe(true); // Runtime errors don't affect success
+      expect(result.success).toBe(false); // Runtime errors don't affect success
       expect(result.frames.length).toBe(2);
 
       const frame = result.frames[1] as TestFrame;
@@ -448,14 +443,13 @@ describe("JavaScript Arrays", () => {
     });
 
     test("error in chained access - non-array in chain", async () => {
-      await changeLanguage("system");
       const code = `
         let matrix = [[1, 2], [3, 4]];
         let value = matrix[0][1][0];
       `;
       const result = interpret(code);
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.frames.length).toBe(2);
 
       const frame = result.frames[1] as TestFrame;

--- a/tests/javascript/concepts/object-property-reading.test.ts
+++ b/tests/javascript/concepts/object-property-reading.test.ts
@@ -210,7 +210,7 @@ describe("Object Property Reading", () => {
         num.property;
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 
@@ -225,7 +225,7 @@ describe("Object Property Reading", () => {
         obj.property;
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 
@@ -240,7 +240,7 @@ describe("Object Property Reading", () => {
         obj.property;
       `;
       const result = interpret(code, { languageFeatures: { requireVariableInstantiation: false } });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 

--- a/tests/javascript/concepts/object-property-writing.test.ts
+++ b/tests/javascript/concepts/object-property-writing.test.ts
@@ -283,7 +283,7 @@ describe("Object Property Writing", () => {
         num.property = "value";
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 
@@ -298,7 +298,7 @@ describe("Object Property Writing", () => {
         str.property = "value";
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 
@@ -313,7 +313,7 @@ describe("Object Property Writing", () => {
         obj.property = "value";
       `;
       const result = interpret(code);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 
@@ -328,7 +328,7 @@ describe("Object Property Writing", () => {
         obj.property = "value";
       `;
       const result = interpret(code, { languageFeatures: { requireVariableInstantiation: false } });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.error).toBe(null);
       expect(result.frames).toHaveLength(2);
 

--- a/tests/javascript/interpreter/null-undefined.test.ts
+++ b/tests/javascript/interpreter/null-undefined.test.ts
@@ -147,7 +147,7 @@ describe("JavaScript Interpreter: null and undefined", () => {
       `;
       const result = interpret(code, { languageFeatures: { allowTruthiness: false } });
       expect(result.error).toBe(null);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.frames[result.frames.length - 1].status).toBe("ERROR");
       expect(result.frames[result.frames.length - 1].error?.type).toBe("TruthinessDisabled");
     });
@@ -161,7 +161,7 @@ describe("JavaScript Interpreter: null and undefined", () => {
       `;
       const result = interpret(code, { languageFeatures: { allowTruthiness: false } });
       expect(result.error).toBe(null);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.frames[result.frames.length - 1].status).toBe("ERROR");
       expect(result.frames[result.frames.length - 1].error?.type).toBe("TruthinessDisabled");
     });
@@ -216,7 +216,7 @@ describe("JavaScript Interpreter: null and undefined", () => {
       const code = "let x = null + 5;";
       const result = interpret(code, { languageFeatures: { allowTypeCoercion: false } });
       expect(result.error).toBe(null);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.frames[0].status).toBe("ERROR");
       expect(result.frames[0].error?.type).toBe("TypeCoercionNotAllowed");
     });
@@ -233,7 +233,7 @@ describe("JavaScript Interpreter: null and undefined", () => {
       const code = "let x = undefined + 5;";
       const result = interpret(code, { languageFeatures: { allowTypeCoercion: false } });
       expect(result.error).toBe(null);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       expect(result.frames[0].status).toBe("ERROR");
       expect(result.frames[0].error?.type).toBe("TypeCoercionNotAllowed");
     });

--- a/tests/javascript/language-features/requireVariableInstantiation.test.ts
+++ b/tests/javascript/language-features/requireVariableInstantiation.test.ts
@@ -9,7 +9,7 @@ describe("requireVariableInstantiation language feature", () => {
       const code = `let x;`;
       const languageFeatures = { requireVariableInstantiation: true };
 
-      expect(() => parse(code, languageFeatures)).toThrow("MissingInitializerInVariableDeclaration");
+      expect(() => parse(code, { languageFeatures })).toThrow("MissingInitializerInVariableDeclaration");
     });
 
     test("should allow initialized variable declaration", () => {

--- a/tests/javascript/language-features/strictEquality.test.ts
+++ b/tests/javascript/language-features/strictEquality.test.ts
@@ -2,7 +2,6 @@ import { interpret } from "@javascript/interpreter";
 import type { TestAugmentedFrame } from "@shared/frames";
 import { RuntimeErrorType } from "@javascript/executor";
 import { Frame } from "@shared/frames";
-import { changeLanguage } from "@javascript/translator";
 
 function expectFrameToBeError(frame: Frame, code: string, type: RuntimeErrorType) {
   expect(frame.code.trim()).toBe(code.trim());
@@ -17,7 +16,6 @@ describe("JavaScript strict equality feature", () => {
     const features = { enforceStrictEquality: true };
 
     test("using == throws StrictEqualityRequired error", () => {
-      changeLanguage("system");
       const code = `let result = 5 == "5";`;
       const { frames, error } = interpret(code, { languageFeatures: features });
       expect(error).toBeNull();
@@ -26,7 +24,6 @@ describe("JavaScript strict equality feature", () => {
     });
 
     test("using != throws StrictEqualityRequired error", () => {
-      changeLanguage("system");
       const code = `let result = 5 != "5";`;
       const { frames, error } = interpret(code, { languageFeatures: features });
       expect(error).toBeNull();
@@ -235,7 +232,6 @@ describe("JavaScript strict equality feature", () => {
 
   describe("default behavior", () => {
     test("default enforces strict equality (enforceStrictEquality: true)", () => {
-      changeLanguage("system");
       const code = `let result = 5 == "5";`;
       const { frames, error } = interpret(code); // No features specified, should use default
       expect(error).toBeNull();

--- a/tests/javascript/scanner.test.ts
+++ b/tests/javascript/scanner.test.ts
@@ -1,7 +1,6 @@
 import { scan } from "@javascript/scanner";
 import { type TokenType } from "@javascript/token";
 import { interpret } from "@javascript/interpreter";
-import { changeLanguage } from "@javascript/translator";
 
 describe("single-character", () => {
   test.each([
@@ -499,9 +498,6 @@ describe.skip("synthetic", () => {
 // When implementing a token, move it from this section to the appropriate section above
 // and uncomment it in the test arrays.
 describe("JavaScript - Unimplemented Tokens", () => {
-  // Set language to system for consistent error messages
-  changeLanguage("system");
-
   describe("Unimplemented Keywords", () => {
     const unimplementedKeywords = [
       { token: "break", type: "BREAK" },

--- a/tests/python/concepts/negation.test.ts
+++ b/tests/python/concepts/negation.test.ts
@@ -37,7 +37,7 @@ describe("negation concepts", () => {
 
   describe("NOT with truthiness (enabled)", () => {
     test("not 0 should return True", () => {
-      const { frames, error } = interpret("not 0", { allowTruthiness: true });
+      const { frames, error } = interpret("not 0", { languageFeatures: { allowTruthiness: true } });
       expect(error).toBeNull();
       expect(frames).toBeArrayOfSize(1);
       expect(frames[0].status).toBe("SUCCESS");
@@ -45,7 +45,7 @@ describe("negation concepts", () => {
     });
 
     test("not 1 should return False", () => {
-      const { frames, error } = interpret("not 1", { allowTruthiness: true });
+      const { frames, error } = interpret("not 1", { languageFeatures: { allowTruthiness: true } });
       expect(error).toBeNull();
       expect(frames).toBeArrayOfSize(1);
       expect(frames[0].status).toBe("SUCCESS");
@@ -53,7 +53,7 @@ describe("negation concepts", () => {
     });
 
     test('not "" should return True', () => {
-      const { frames, error } = interpret('not ""', { allowTruthiness: true });
+      const { frames, error } = interpret('not ""', { languageFeatures: { allowTruthiness: true } });
       expect(error).toBeNull();
       expect(frames).toBeArrayOfSize(1);
       expect(frames[0].status).toBe("SUCCESS");
@@ -61,7 +61,7 @@ describe("negation concepts", () => {
     });
 
     test('not "hello" should return False', () => {
-      const { frames, error } = interpret('not "hello"', { allowTruthiness: true });
+      const { frames, error } = interpret('not "hello"', { languageFeatures: { allowTruthiness: true } });
       expect(error).toBeNull();
       expect(frames).toBeArrayOfSize(1);
       expect(frames[0].status).toBe("SUCCESS");
@@ -69,7 +69,7 @@ describe("negation concepts", () => {
     });
 
     test("not None should return True", () => {
-      const { frames, error } = interpret("not None", { allowTruthiness: true });
+      const { frames, error } = interpret("not None", { languageFeatures: { allowTruthiness: true } });
       expect(error).toBeNull();
       expect(frames).toBeArrayOfSize(1);
       expect(frames[0].status).toBe("SUCCESS");

--- a/tests/python/concepts/typeCoercion.test.ts
+++ b/tests/python/concepts/typeCoercion.test.ts
@@ -9,7 +9,9 @@ describe("Python Type Coercion", () => {
 
   describe("with allowTypeCoercion disabled (default)", () => {
     const languageFeatures = {
-      allowTypeCoercion: false,
+      languageFeatures: {
+        allowTypeCoercion: false,
+      },
     };
 
     describe("arithmetic operations", () => {
@@ -289,7 +291,9 @@ s + 42`,
 
   describe("with allowTypeCoercion enabled", () => {
     const languageFeatures = {
-      allowTypeCoercion: true,
+      languageFeatures: {
+        allowTypeCoercion: true,
+      },
     };
 
     describe("arithmetic operations with coercion", () => {

--- a/tests/python/concepts/typeCoercion.test.ts
+++ b/tests/python/concepts/typeCoercion.test.ts
@@ -1,12 +1,7 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect } from "vitest";
 import { interpret } from "../../../src/python/interpreter";
-import { changeLanguage } from "../../../src/python/translator";
 
 describe("Python Type Coercion", () => {
-  beforeEach(() => {
-    changeLanguage("system");
-  });
-
   describe("with allowTypeCoercion disabled (default)", () => {
     const languageFeatures = {
       languageFeatures: {

--- a/tests/python/external-functions.test.ts
+++ b/tests/python/external-functions.test.ts
@@ -219,4 +219,58 @@ describe("Python External Functions", () => {
       expect(receivedContext).toHaveProperty("getCurrentTimeInMs");
     });
   });
+
+  describe("Error handling", () => {
+    it("should catch and report errors thrown by external functions", () => {
+      const throwingFunc: ExternalFunction = {
+        name: "throwError",
+        func: (_ctx: ExecutionContext) => {
+          throw new Error("Something went wrong");
+        },
+        description: "Function that throws an error",
+        arity: 0,
+      };
+
+      const result = interpret("throwError()", { externalFunctions: [throwingFunc] });
+
+      expect(result.error).toBeNull(); // Runtime errors don't become parse errors
+      expect(result.success).toBe(false);
+      expect(result.frames).toHaveLength(1);
+      expect(result.frames[0].status).toBe("ERROR");
+      expect((result.frames[0] as any).error.type).toBe("FunctionExecutionError");
+      expect((result.frames[0] as any).error.message).toBe(
+        "FunctionExecutionError: function: throwError: message: Something went wrong"
+      );
+    });
+
+    it("should handle errors with arguments", () => {
+      const throwingFunc: ExternalFunction = {
+        name: "riskyOperation",
+        func: (_ctx: ExecutionContext, value: number) => {
+          if (value < 0) {
+            throw new Error("Negative values not allowed");
+          }
+          return value * 2;
+        },
+        description: "Function that might throw",
+        arity: 1,
+      };
+
+      // Should work with valid input
+      let result = interpret("riskyOperation(5)", { externalFunctions: [throwingFunc] });
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(10);
+
+      // Should throw with invalid input
+      result = interpret("riskyOperation(-5)", { externalFunctions: [throwingFunc] });
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(false);
+      expect(result.frames[0].status).toBe("ERROR");
+      expect((result.frames[0] as any).error.type).toBe("FunctionExecutionError");
+      expect((result.frames[0] as any).error.message).toBe(
+        "FunctionExecutionError: function: riskyOperation: message: Negative values not allowed"
+      );
+    });
+  });
 });

--- a/tests/python/external-functions.test.ts
+++ b/tests/python/external-functions.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { interpret } from "../../src/python/interpreter";
+import type { ExternalFunction } from "../../src/shared/interfaces";
+import type { ExecutionContext } from "../../src/shared/interfaces";
+
+describe("Python External Functions", () => {
+  describe("Basic function calls", () => {
+    it("should call an external function with no arguments", () => {
+      const testFunc: ExternalFunction = {
+        name: "test",
+        func: (_ctx: ExecutionContext) => 42,
+        description: "Test function",
+      };
+
+      const result = interpret("test()", { externalFunctions: [testFunc] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(result.frames).toHaveLength(1);
+      expect(result.frames[0].status).toBe("SUCCESS");
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(42);
+    });
+
+    it("should call an external function with one argument", () => {
+      const double: ExternalFunction = {
+        name: "double",
+        func: (_ctx: ExecutionContext, x: number) => x * 2,
+        description: "Doubles a number",
+        arity: 1,
+      };
+
+      const result = interpret("double(5)", { externalFunctions: [double] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(result.frames).toHaveLength(1);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(10);
+    });
+
+    it("should call an external function with multiple arguments", () => {
+      const add: ExternalFunction = {
+        name: "add",
+        func: (_ctx: ExecutionContext, a: number, b: number) => a + b,
+        description: "Adds two numbers",
+        arity: 2,
+      };
+
+      const result = interpret("add(3, 4)", { externalFunctions: [add] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(result.frames).toHaveLength(1);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(7);
+    });
+  });
+
+  describe("Arity checking", () => {
+    it("should enforce exact arity", () => {
+      const func: ExternalFunction = {
+        name: "exactTwo",
+        func: (_ctx: ExecutionContext, a: number, b: number) => a + b,
+        description: "Requires exactly 2 arguments",
+        arity: 2,
+      };
+
+      const result = interpret("exactTwo(1)", { externalFunctions: [func] });
+
+      expect(result.success).toBe(false);
+      expect(result.frames[0].status).toBe("ERROR");
+      expect((result.frames[0] as any).error.type).toBe("InvalidNumberOfArguments");
+    });
+
+    it("should enforce variable arity with min and max", () => {
+      const func: ExternalFunction = {
+        name: "variableArgs",
+        func: (_ctx: ExecutionContext, ...args: number[]) => args.reduce((a, b) => a + b, 0),
+        description: "Accepts 1-3 arguments",
+        arity: [1, 3],
+      };
+
+      // Too few arguments
+      let result = interpret("variableArgs()", { externalFunctions: [func] });
+      expect(result.success).toBe(false);
+      expect((result.frames[0] as any).error.type).toBe("InvalidNumberOfArguments");
+
+      // Valid number of arguments
+      result = interpret("variableArgs(1, 2)", { externalFunctions: [func] });
+      expect(result.success).toBe(true);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(3);
+
+      // Too many arguments
+      result = interpret("variableArgs(1, 2, 3, 4)", { externalFunctions: [func] });
+      expect(result.success).toBe(false);
+      expect((result.frames[0] as any).error.type).toBe("InvalidNumberOfArguments");
+    });
+  });
+
+  describe("Complex expressions as arguments", () => {
+    it("should evaluate expressions before passing to function", () => {
+      const double: ExternalFunction = {
+        name: "double",
+        func: (_ctx: ExecutionContext, x: number) => x * 2,
+        description: "Doubles a number",
+        arity: 1,
+      };
+
+      const result = interpret("double(3 + 2)", { externalFunctions: [double] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(result.frames).toHaveLength(1);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(10);
+    });
+
+    it("should work with variables as arguments", () => {
+      const square: ExternalFunction = {
+        name: "square",
+        func: (_ctx: ExecutionContext, x: number) => x * x,
+        description: "Squares a number",
+        arity: 1,
+      };
+
+      const result = interpret("x = 5\nsquare(x)", { externalFunctions: [square] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(result.frames).toHaveLength(2);
+      expect((result.frames[1] as any).result.jikiObject.value).toBe(25);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should error when function is not found", () => {
+      const result = interpret("nonexistent()");
+
+      expect(result.success).toBe(false);
+      expect(result.frames[0].status).toBe("ERROR");
+      // When identifier doesn't exist as variable or external function, we get UndefinedVariable
+      expect((result.frames[0] as any).error.type).toBe("UndefinedVariable");
+    });
+
+    it("should error when trying to call non-function", () => {
+      const result = interpret("x = 5\nx()");
+
+      expect(result.success).toBe(false);
+      expect(result.frames[1].status).toBe("ERROR");
+      expect((result.frames[1] as any).error.type).toBe("TypeError");
+    });
+  });
+
+  describe("Return value types", () => {
+    it("should handle string return values", () => {
+      const greet: ExternalFunction = {
+        name: "greet",
+        func: (_ctx: ExecutionContext, name: string) => `Hello, ${name}!`,
+        description: "Greets someone",
+        arity: 1,
+      };
+
+      const result = interpret('greet("World")', { externalFunctions: [greet] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe("Hello, World!");
+    });
+
+    it("should handle boolean return values", () => {
+      const isEven: ExternalFunction = {
+        name: "isEven",
+        func: (_ctx: ExecutionContext, n: number) => n % 2 === 0,
+        description: "Checks if number is even",
+        arity: 1,
+      };
+
+      const result = interpret("isEven(4)", { externalFunctions: [isEven] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect((result.frames[0] as any).result.jikiObject.value).toBe(true);
+    });
+
+    it("should handle array return values", () => {
+      const range: ExternalFunction = {
+        name: "range",
+        func: (_ctx: ExecutionContext, n: number) => Array.from({ length: n }, (_, i) => i),
+        description: "Creates a range",
+        arity: 1,
+      };
+
+      const result = interpret("range(3)", { externalFunctions: [range] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      const returnValue = (result.frames[0] as any).result.jikiObject;
+      expect(returnValue.type).toBe("list");
+      expect(returnValue.value.map((item: any) => item.value)).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe("ExecutionContext usage", () => {
+    it("should pass ExecutionContext to external functions", () => {
+      let receivedContext: ExecutionContext | null = null;
+
+      const checkContext: ExternalFunction = {
+        name: "checkContext",
+        func: (ctx: ExecutionContext) => {
+          receivedContext = ctx;
+          return true;
+        },
+        description: "Checks context",
+      };
+
+      const result = interpret("checkContext()", { externalFunctions: [checkContext] });
+
+      expect(result.error).toBeNull();
+      expect(result.success).toBe(true);
+      expect(receivedContext).not.toBeNull();
+      expect(receivedContext).toHaveProperty("fastForward");
+      expect(receivedContext).toHaveProperty("getCurrentTimeInMs");
+    });
+  });
+});

--- a/tests/python/language-features/allowedNodes.test.ts
+++ b/tests/python/language-features/allowedNodes.test.ts
@@ -19,7 +19,7 @@ if x > 5:
 for i in [1, 2, 3]:
     x = x + 1
       `.trim();
-      const { error, frames } = interpret(code, { allowedNodes: null });
+      const { error, frames } = interpret(code, { languageFeatures: { allowedNodes: null } });
       expect(error).toBeNull();
       expect(frames.length).toBeGreaterThan(0);
     });
@@ -40,7 +40,7 @@ if x > 5:
   describe("allowedNodes: [] (empty array)", () => {
     test("prevents all parsing when allowedNodes is empty", () => {
       const code = `5`;
-      const { error, frames } = interpret(code, { allowedNodes: [] });
+      const { error, frames } = interpret(code, { languageFeatures: { allowedNodes: [] } });
       expect(error).toBeInstanceOf(SyntaxError);
       expect(error?.type).toBe("ExpressionStatementNotAllowed");
       expect(frames).toHaveLength(0);
@@ -48,7 +48,7 @@ if x > 5:
 
     test("cannot even parse literals with empty allowedNodes", () => {
       const code = `42`;
-      const { error, frames } = interpret(code, { allowedNodes: [] });
+      const { error, frames } = interpret(code, { languageFeatures: { allowedNodes: [] } });
       expect(error).toBeInstanceOf(SyntaxError);
       expect(error?.type).toBe("ExpressionStatementNotAllowed");
       expect(frames).toHaveLength(0);
@@ -60,7 +60,7 @@ if x > 5:
       test("allows assignments when included", () => {
         const code = `x = 5`;
         const allowedNodes: NodeType[] = ["AssignmentStatement", "LiteralExpression", "IdentifierExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -68,7 +68,7 @@ if x > 5:
       test("prevents assignments when not included", () => {
         const code = `x = 5`;
         const allowedNodes: NodeType[] = ["LiteralExpression", "ExpressionStatement"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("AssignmentStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -82,7 +82,7 @@ if True:
     1
         `.trim();
         const allowedNodes: NodeType[] = ["IfStatement", "BlockStatement", "LiteralExpression", "ExpressionStatement"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -93,7 +93,7 @@ if True:
     1
         `.trim();
         const allowedNodes: NodeType[] = ["BlockStatement", "LiteralExpression", "ExpressionStatement"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("IfStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -114,7 +114,7 @@ for i in [1, 2, 3]:
           "IdentifierExpression",
           "AssignmentStatement",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -125,7 +125,7 @@ for i in [1, 2]:
     x = i
         `.trim();
         const allowedNodes: NodeType[] = ["ListExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ForInStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -146,7 +146,7 @@ for i in [1]:
           "LiteralExpression",
           "IdentifierExpression",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -157,7 +157,7 @@ for i in [1]:
     break
         `.trim();
         const allowedNodes: NodeType[] = ["ForInStatement", "BlockStatement", "ListExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("BreakStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -178,7 +178,7 @@ for i in [1]:
           "LiteralExpression",
           "IdentifierExpression",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -189,7 +189,7 @@ for i in [1]:
     continue
         `.trim();
         const allowedNodes: NodeType[] = ["ForInStatement", "BlockStatement", "ListExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ContinueStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -203,7 +203,7 @@ if True:
     1
         `.trim();
         const allowedNodes: NodeType[] = ["IfStatement", "BlockStatement", "ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -214,7 +214,7 @@ if True:
     1
         `.trim();
         const allowedNodes: NodeType[] = ["IfStatement", "ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("BlockStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -225,7 +225,7 @@ if True:
       test("allows expression statements when included", () => {
         const code = `5`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -233,7 +233,7 @@ if True:
       test("prevents expression statements when not included", () => {
         const code = `5`;
         const allowedNodes: NodeType[] = ["LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ExpressionStatementNotAllowed");
         expect(frames).toHaveLength(0);
@@ -246,7 +246,7 @@ if True:
       test("allows literals when included", () => {
         const code = `42`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -254,7 +254,7 @@ if True:
       test("prevents literals when not included", () => {
         const code = `42`;
         const allowedNodes: NodeType[] = ["ExpressionStatement"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("LiteralExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -272,7 +272,7 @@ if True:
         const allowedNodes: NodeType[] = ["ExpressionStatement"];
 
         for (const { code, desc } of testCases) {
-          const { error } = interpret(code, { allowedNodes });
+          const { error } = interpret(code, { languageFeatures: { allowedNodes } });
           expect(error).toBeInstanceOf(SyntaxError);
           expect(error?.type).toBe("LiteralExpressionNotAllowed");
         }
@@ -283,7 +283,7 @@ if True:
       test("allows binary expressions when included", () => {
         const code = `1 + 2`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "BinaryExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -291,7 +291,7 @@ if True:
       test("prevents binary expressions when not included", () => {
         const code = `1 + 2`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("BinaryExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -316,7 +316,7 @@ if True:
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
 
         for (const { code, op } of testCases) {
-          const { error } = interpret(code, { allowedNodes });
+          const { error } = interpret(code, { languageFeatures: { allowedNodes } });
           expect(error).toBeInstanceOf(SyntaxError);
           expect(error?.type).toBe("BinaryExpressionNotAllowed");
         }
@@ -327,7 +327,7 @@ if True:
       test("allows unary expressions when included", () => {
         const code = `-5`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "UnaryExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -335,7 +335,7 @@ if True:
       test("prevents unary expressions when not included", () => {
         const code = `-5`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("UnaryExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -344,7 +344,7 @@ if True:
       test("prevents not operator", () => {
         const code = `not True`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("UnaryExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -363,7 +363,7 @@ x
           "IdentifierExpression",
           "LiteralExpression",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -374,7 +374,7 @@ x = 5
 x
         `.trim();
         const allowedNodes: NodeType[] = ["AssignmentStatement", "ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("IdentifierExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -385,7 +385,7 @@ x
       test("allows grouping when included", () => {
         const code = `(5)`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "GroupingExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -393,7 +393,7 @@ x
       test("prevents grouping when not included", () => {
         const code = `(5)`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("GroupingExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -404,7 +404,7 @@ x
       test("allows lists when included", () => {
         const code = `[1, 2, 3]`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "ListExpression", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -412,7 +412,7 @@ x
       test("prevents lists when not included", () => {
         const code = `[1, 2, 3]`;
         const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("ListExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -433,7 +433,7 @@ lst[0]
           "IdentifierExpression",
           "LiteralExpression",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeNull();
         expect(frames.length).toBeGreaterThan(0);
       });
@@ -450,7 +450,7 @@ lst[0]
           "IdentifierExpression",
           "LiteralExpression",
         ];
-        const { error, frames } = interpret(code, { allowedNodes });
+        const { error, frames } = interpret(code, { languageFeatures: { allowedNodes } });
         expect(error).toBeInstanceOf(SyntaxError);
         expect(error?.type).toBe("SubscriptExpressionNotAllowed");
         expect(frames).toHaveLength(0);
@@ -463,15 +463,15 @@ lst[0]
       const allowedNodes: NodeType[] = ["ExpressionStatement", "LiteralExpression"];
 
       // Should work
-      const { error: error1 } = interpret(`5`, { allowedNodes });
+      const { error: error1 } = interpret(`5`, { languageFeatures: { allowedNodes } });
       expect(error1).toBeNull();
 
       // Should fail - needs assignment
-      const { error: error2 } = interpret(`x = 5`, { allowedNodes });
+      const { error: error2 } = interpret(`x = 5`, { languageFeatures: { allowedNodes } });
       expect(error2?.type).toBe("AssignmentStatementNotAllowed");
 
       // Should fail - needs binary expression
-      const { error: error3 } = interpret(`1 + 2`, { allowedNodes });
+      const { error: error3 } = interpret(`1 + 2`, { languageFeatures: { allowedNodes } });
       expect(error3?.type).toBe("BinaryExpressionNotAllowed");
     });
 
@@ -484,12 +484,12 @@ lst[0]
       ];
 
       // Should work
-      const { error: error1, frames: frames1 } = interpret(`(1 + 2) * 3`, { allowedNodes });
+      const { error: error1, frames: frames1 } = interpret(`(1 + 2) * 3`, { languageFeatures: { allowedNodes } });
       expect(error1).toBeNull();
       expect(frames1.length).toBeGreaterThan(0);
 
       // Should fail - needs assignment
-      const { error: error2 } = interpret(`x = 1 + 2`, { allowedNodes });
+      const { error: error2 } = interpret(`x = 1 + 2`, { languageFeatures: { allowedNodes } });
       expect(error2?.type).toBe("AssignmentStatementNotAllowed");
     });
 
@@ -509,7 +509,7 @@ x = 5
 x = x + 1
 x
       `.trim(),
-        { allowedNodes }
+        { languageFeatures: { allowedNodes } }
       );
       expect(error1).toBeNull();
       expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(6);
@@ -521,7 +521,7 @@ x = 5
 if x > 0:
     x = 10
       `.trim(),
-        { allowedNodes }
+        { languageFeatures: { allowedNodes } }
       );
       expect(error2?.type).toBe("IfStatementNotAllowed");
     });
@@ -544,7 +544,7 @@ x = 5
 if x > 0:
     x = 10
       `.trim(),
-        { allowedNodes }
+        { languageFeatures: { allowedNodes } }
       );
       expect(error1).toBeNull();
       expect((frames1[frames1.length - 1] as TestAugmentedFrame).variables.x.value).toBe(10);
@@ -555,7 +555,7 @@ if x > 0:
 for i in [1, 2, 3]:
     x = i
       `.trim(),
-        { allowedNodes }
+        { languageFeatures: { allowedNodes } }
       );
       expect(error2?.type).toBe("ForInStatementNotAllowed");
     });

--- a/tests/python/language-features/truthiness.test.ts
+++ b/tests/python/language-features/truthiness.test.ts
@@ -13,7 +13,7 @@ function expectFrameToBeError(frame: Frame, code: string, type: RuntimeErrorType
 
 describe("Python truthiness feature", () => {
   describe("allowTruthiness: true", () => {
-    const features = { allowTruthiness: true };
+    const features = { languageFeatures: { allowTruthiness: true } };
 
     describe("not operator", () => {
       test("numbers - 0 is falsy", () => {
@@ -230,7 +230,7 @@ result = (a and not b) or (b and not a)`;
   describe("explicit allowTruthiness: false", () => {
     test("truthiness disabled when explicitly set to false", () => {
       const code = "result = 1 and 2";
-      const { frames } = interpret(code, { allowTruthiness: false });
+      const { frames } = interpret(code, { languageFeatures: { allowTruthiness: false } });
       expectFrameToBeError(frames[0], code, "TruthinessDisabled");
       expect(frames[0].error!.message).toBe("TruthinessDisabled: value: number");
     });

--- a/tests/python/parser/for.test.ts
+++ b/tests/python/parser/for.test.ts
@@ -6,7 +6,7 @@ import { IdentifierExpression, ListExpression } from "../../../src/python/expres
 describe("Python Parser - For Loops", () => {
   describe("Basic for-in loops", () => {
     it("should parse a simple for loop over a list", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in [1, 2, 3]:
     x`;
 
@@ -22,7 +22,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should parse a for loop over an identifier", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for item in items:
     item`;
 
@@ -38,7 +38,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should parse a for loop with multiple statements in body", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for n in numbers:
     n = n + 1
     total = total + n`;
@@ -53,7 +53,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should parse an empty for loop", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in []:
     x`; // Use x instead of pass since pass is not implemented
 
@@ -70,7 +70,7 @@ describe("Python Parser - For Loops", () => {
 
   describe("Break and Continue statements", () => {
     it("should parse a break statement", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in items:
     break`;
 
@@ -83,7 +83,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should parse a continue statement", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in items:
     continue`;
 
@@ -96,7 +96,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should parse a loop with both break and continue", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in items:
     if x > 5:
         break
@@ -114,7 +114,7 @@ describe("Python Parser - For Loops", () => {
 
   describe("Nested for loops", () => {
     it("should parse nested for loops", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in [1, 2]:
     for y in [3, 4]:
         x + y`;
@@ -134,7 +134,7 @@ describe("Python Parser - For Loops", () => {
 
   describe("Syntax errors", () => {
     it("should throw error for missing variable name", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for in items:
     x`;
 
@@ -142,7 +142,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should throw error for missing 'in' keyword", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x items:
     x`;
 
@@ -150,7 +150,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should throw error for missing colon", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in items
     x`;
 
@@ -158,7 +158,7 @@ describe("Python Parser - For Loops", () => {
     });
 
     it("should throw error for missing indented block", () => {
-      const parser = new Parser("test.py");
+      const parser = new Parser("test.py", {});
       const code = `for x in items:
 x`;
 

--- a/tests/python/parser/if.test.ts
+++ b/tests/python/parser/if.test.ts
@@ -6,7 +6,7 @@ describe("Python Parser - If Statements", () => {
   let parser: Parser;
 
   beforeEach(() => {
-    parser = new Parser("test.py");
+    parser = new Parser("test.py", {});
   });
 
   test("parses simple if statement", () => {

--- a/tests/python/scanner.test.ts
+++ b/tests/python/scanner.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { interpret } from "../../src/python/interpreter";
-import { changeLanguage } from "../../src/python/translator";
 
 // UNIMPLEMENTED TOKENS
 // When implementing a token, move it from this section to the appropriate implemented section
 // and create proper scanner tests for it.
 describe("Python - Unimplemented Tokens", () => {
-  // Set language to system for consistent error messages
-  changeLanguage("system");
-
   describe("Unimplemented Keywords", () => {
     const unimplementedKeywords = [
       { token: "as", type: "AS" },


### PR DESCRIPTION
## Summary
- Added external function support to Python interpreter following the same pattern as JavaScript
- Updated both Python and JavaScript to consistently use EvaluationContext for parser and executor
- Added comprehensive tests for Python external functions

## Changes
- ✨ Added CallExpression AST node and parser support for Python
- ✨ Implemented executeCallExpression with arity checking
- ✨ Added CallExpression describer for educational output  
- 🔧 Updated Python and JavaScript parsers/executors to accept EvaluationContext
- 🔧 Made context parameter handling consistent across both interpreters
- ✅ Added comprehensive tests for external functions in Python
- 📝 Updated TODO.md to mark Python external functions as complete

## Test plan
- [x] All existing tests pass
- [x] New Python external function tests pass
- [x] TypeScript type checking passes
- [x] ESLint checks pass
- [x] Prettier formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)